### PR TITLE
Better FUSE performance

### DIFF
--- a/bin/menmos-fuse/src/menmos_fs/fs/common.rs
+++ b/bin/menmos-fuse/src/menmos_fs/fs/common.rs
@@ -1,5 +1,5 @@
-use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::{collections::HashMap, time::Instant};
 
 use anyhow::{anyhow, ensure, Result};
 
@@ -20,6 +20,8 @@ pub struct MenmosFS {
     pub(crate) blobid_to_inode: ConcurrentMap<String, u64>,
     pub(crate) inode_to_blobid: ConcurrentMap<u64, String>,
     pub(crate) name_to_blobid: ConcurrentMap<(u64, String), String>,
+
+    pub(crate) inode_to_last_refresh: ConcurrentMap<u64, Instant>,
 
     pub(crate) virtual_directories_inodes: ConcurrentMap<u64, VirtualDirectory>,
     pub(crate) virtual_directories: ConcurrentMap<(u64, String), u64>,
@@ -43,6 +45,8 @@ impl MenmosFS {
             inode_to_blobid: Default::default(),
             name_to_blobid: Default::default(),
             inode_counter: AtomicU64::new(3),
+
+            inode_to_last_refresh: ConcurrentMap::new(),
 
             virtual_directories_inodes: ConcurrentMap::new(),
             virtual_directories: Default::default(),

--- a/bin/menmos-fuse/src/menmos_fs/fs/release.rs
+++ b/bin/menmos-fuse/src/menmos_fs/fs/release.rs
@@ -3,7 +3,7 @@ use crate::MenmosFS;
 use super::{Error, Result};
 
 impl MenmosFS {
-    pub async fn release_impl(&self, ino: u64) -> Result<()> {
+    pub async fn release_impl(&self, ino: u64, is_writable: bool) -> Result<()> {
         log::info!("release i{}", ino);
         let mut buffers_guard = self.write_buffers.lock().await;
         if let Some(buffer) = buffers_guard.remove(&ino) {
@@ -17,13 +17,14 @@ impl MenmosFS {
             .await
             .ok_or(Error::NotFound)?;
 
-        // TODO: Don't call fsync if the file wasn't open for writing.
-        log::info!("calling fsync");
-        self.client.fsync(&blob_id).await.map_err(|e| {
-            log::error!("menmos fsync error: {}", e);
-            Error::IOError
-        })?;
-        log::info!("fsync complete");
+        if is_writable {
+            log::info!("start fsync {}", blob_id);
+            self.client.fsync(&blob_id).await.map_err(|e| {
+                log::error!("menmos fsync error: {}", e);
+                Error::IOError
+            })?;
+            log::info!("fsync {} complete", blob_id);
+        }
 
         Ok(())
     }


### PR DESCRIPTION
This fixes a regression in the previous PR where calling listdir on every lookup created n^2 calls to the server when using a file browser (because the browser does a single readdir followed by one lookup per dir entry)

This also fixes an existing issue where `/{blob_id}/fsync` would be called by FUSE despite the file being opened in readonly mode.