### PR TITLE
Improved CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -351,6 +351,12 @@ checksum = "4c0496836a84f8d0495758516b8621a622beb77c0fed418570e50764093ced48"
 
 [[package]]
 name = "cfg-if"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+
+[[package]]
+name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
@@ -509,7 +515,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81156fece84ab6a9f2afdb109ce3ae577e42b1228441eded99bd77f627953b1a"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -518,7 +524,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1aaa739f95311c2c7887a76863f500026092fb1dce0161dab577e559ef3569d"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "const_fn",
  "crossbeam-utils",
  "lazy_static",
@@ -533,7 +539,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02d96d1e189ef58269ebe5b97953da3274d83a93af647c2ddd6f9dab28cedb8d"
 dependencies = [
  "autocfg 1.0.1",
- "cfg-if",
+ "cfg-if 1.0.0",
  "lazy_static",
 ]
 
@@ -623,7 +629,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "dirs-sys-next",
 ]
 
@@ -687,7 +693,7 @@ version = "0.8.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80df024fbc5ac80f87dfef0d9f5209a252f2a497f7f42944cff24d8253cac065"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -947,7 +953,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "wasi 0.9.0+wasi-snapshot-preview1",
 ]
@@ -958,7 +964,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9495705279e7140bf035dde1f6e750c162df8b625267cd52cc44e0b156732c8"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "wasi 0.10.2+wasi-snapshot-preview1",
 ]
@@ -1216,7 +1222,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61124eeebbd69b8190558df225adf7e4caafce0d743919e5d6b19652314ec5ec"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -1291,7 +1297,7 @@ checksum = "21f866863575d0e1d654fbeeabdc927292fdf862873dc3c96c6f753357e13374"
 dependencies = [
  "arrayvec",
  "bitflags",
- "cfg-if",
+ "cfg-if 1.0.0",
  "ryu",
  "static_assertions",
 ]
@@ -1347,7 +1353,7 @@ version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "serde 1.0.123",
 ]
 
@@ -1446,6 +1452,7 @@ dependencies = [
  "futures",
  "interface",
  "menmos-client",
+ "nix",
  "rood",
  "serde 1.0.123",
  "tokio",
@@ -1645,6 +1652,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50e4785f2c3b7589a0d0c1dd60285e1188adac4006e8abd6dd578e1567027363"
+dependencies = [
+ "bitflags",
+ "cc",
+ "cfg-if 0.1.10",
+ "libc",
+ "void",
+]
+
+[[package]]
 name = "nom"
 version = "5.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1759,7 +1779,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "038d43985d1ddca7a9900630d8cd031b56e4794eecc2e9ea39dd17aa04399a70"
 dependencies = [
  "bitflags",
- "cfg-if",
+ "cfg-if 1.0.0",
  "foreign-types",
  "lazy_static",
  "libc",
@@ -1829,7 +1849,7 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa7a782938e745763fe6907fc6ba86946d72f49fe7e21de074e08128a99fb018"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "instant",
  "libc",
  "redox_syscall 0.2.4",
@@ -2393,10 +2413,11 @@ dependencies = [
 
 [[package]]
 name = "rood"
-version = "0.3.2"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b81f05ee0f568eba0e9bc104ee626d09a6860211c78a892d0cba9db6ff74c45d"
+checksum = "2289e081c7a114bf4bc6bdb31642ea5b39540d4e1aa5631f1d7761d2a947e98c"
 dependencies = [
+ "atty",
  "colored",
  "rpassword",
 ]
@@ -2750,7 +2771,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4b312c3731e3fe78a185e6b9b911a7aa715b8e31cce117975219aab2acf285d"
 dependencies = [
  "block-buffer 0.9.0",
- "cfg-if",
+ "cfg-if 1.0.0",
  "cpuid-bool",
  "digest 0.9.0",
  "opaque-debug 0.3.0",
@@ -2769,7 +2790,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa827a14b29ab7f44778d14a88d3cb76e949c45083f7dbfa507d0cb699dc12de"
 dependencies = [
  "block-buffer 0.9.0",
- "cfg-if",
+ "cfg-if 1.0.0",
  "cpuid-bool",
  "digest 0.9.0",
  "opaque-debug 0.3.0",
@@ -2868,7 +2889,7 @@ version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "122e570113d28d773067fab24266b66753f6ea915758651696b6e35e49f88d6e"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "winapi",
 ]
@@ -2978,7 +2999,7 @@ version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "rand 0.8.3",
  "redox_syscall 0.2.4",
@@ -3235,7 +3256,7 @@ version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7d40a22fd029e33300d8d89a5cc8ffce18bb7c587662f54629e94c9de5487f3"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "log",
  "pin-project-lite",
  "tracing-core",
@@ -3272,7 +3293,7 @@ version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "498e4de74132fb535c0608d0f221a3e64ddf6585717296afb2baf5925b38f31f"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "chrono",
  "data-encoding",
  "futures-channel",
@@ -3293,7 +3314,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98a0381b2864c2978db7f8e17c7b23cca5a3a5f99241076e13002261a8ecbabd"
 dependencies = [
  "async-trait",
- "cfg-if",
+ "cfg-if 1.0.0",
  "data-encoding",
  "enum-as-inner",
  "futures-channel",
@@ -3316,7 +3337,7 @@ version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3072d18c10bd621cb00507d59cfab5517862285c353160366e37fbf4c74856e4"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "futures-util",
  "ipconfig",
  "lazy_static",
@@ -3532,6 +3553,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
 
 [[package]]
+name = "void"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+
+[[package]]
 name = "walkdir"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3601,7 +3628,7 @@ version = "0.2.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55c0f7123de74f0dab9b7d00fd614e7b19349cd1e2f5252bbe9b1754b59433be"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "serde 1.0.123",
  "serde_json",
  "wasm-bindgen-macro",
@@ -3628,7 +3655,7 @@ version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3de431a2910c86679c34283a33f66f4e4abd7e0aec27b6669060148872aadf94"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "js-sys",
  "wasm-bindgen",
  "web-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,3 @@
-
 [workspace]
 members = [
     "bin/amphora",

--- a/bin/menmos-cli/Cargo.toml
+++ b/bin/menmos-cli/Cargo.toml
@@ -27,7 +27,10 @@ serde = {version = "1", features = ["derive"]}
 tokio = {version = "1.2", features = ["full"]}
 walkdir = "2.3"
 
+[target.'cfg(target_family = "unix")'.dependencies]
+nix = "0.17.0"
+
 [dependencies.rood]
-version = "0.3.2"
+version = "0.4"
 default-features = false
 features = ["cli"]

--- a/bin/menmos-cli/src/cli/download.rs
+++ b/bin/menmos-cli/src/cli/download.rs
@@ -19,6 +19,9 @@ pub struct DownloadCommand {
     /// The directory to which to save the files.
     #[clap(long = "out", short = 'o')]
     dst_dir: Option<PathBuf>,
+
+    #[clap(long = "concurrency", short = 'c', default_value = "4")]
+    concurrency: usize,
 }
 
 impl DownloadCommand {
@@ -28,44 +31,57 @@ impl DownloadCommand {
             let stdin = io::stdin();
             stdin.lock().lines().filter_map(|l| l.ok()).collect()
         } else {
-            self.blob_ids
+            self.blob_ids.clone()
         };
 
-        // TODO: Extract to service & parallelize.
         cli.step(format!("Downloading {} files...", &blob_ids.len()));
 
         let pushed = cli.push();
-        for blob_id in blob_ids.into_iter() {
-            pushed.step(format!("Downloading blob {}...", &blob_id));
-            let meta = match client.get_meta(&blob_id).await? {
-                Some(b) => b,
-                None => {
-                    cli.error("404 - Blob not found");
-                    continue;
-                }
-            };
+        let results = futures::stream::iter(blob_ids.into_iter())
+            .map(|blob_id| {
+                let pushed = pushed.clone();
+                let client = client.clone();
+                let cli = cli.clone();
+                let dst_dir = self.dst_dir.clone();
+                async move {
+                    let meta = match client.get_meta(&blob_id).await? {
+                        Some(b) => b,
+                        None => {
+                            cli.error("404 - Blob not found");
+                            return Ok(());
+                        }
+                    };
 
-            let stream = client.get_file(&blob_id).await?;
-            let mut stream_pin = Box::pin(stream);
+                    let stream = client.get_file(&blob_id).await?;
+                    let mut stream_pin = Box::pin(stream);
 
-            let file_path = match &self.dst_dir {
-                Some(d) => d.join(&meta.name),
-                None => PathBuf::from(meta.name),
-            };
+                    let file_path = match &dst_dir {
+                        Some(d) => d.join(&meta.name),
+                        None => PathBuf::from(meta.name),
+                    };
 
-            let mut f = fs::File::create(&file_path).await?;
+                    let mut f = fs::File::create(&file_path).await?;
 
-            while let Some(chunk) = stream_pin.next().await {
-                match chunk {
-                    Ok(c) => f.write_all(c.as_ref()).await?,
-                    Err(e) => {
-                        fs::remove_file(&file_path).await?;
-                        return Err(anyhow!("{}", e.to_string()));
+                    while let Some(chunk) = stream_pin.next().await {
+                        match chunk {
+                            Ok(c) => f.write_all(c.as_ref()).await?,
+                            Err(e) => {
+                                fs::remove_file(&file_path).await?;
+                                return Err(anyhow!("{}", e.to_string()));
+                            }
+                        }
                     }
+                    pushed.success(format!("Downloaded {} to {:?}", blob_id, file_path));
+
+                    Ok(())
                 }
-            }
-            pushed.success("Done");
-        }
+            })
+            .buffer_unordered(self.concurrency)
+            .collect::<Vec<Result<()>>>()
+            .await;
+
+        // Catch any errors that occurred.
+        results.into_iter().collect::<Result<Vec<()>>>()?;
 
         cli.success("Done.");
         Ok(())

--- a/bin/menmos-cli/src/cli/mod.rs
+++ b/bin/menmos-cli/src/cli/mod.rs
@@ -58,9 +58,11 @@ impl Root {
 #[derive(Clap)]
 enum Command {
     /// Delete a blob from a menmos cluster.
+    #[clap(name = "delete")]
     Delete(delete::DeleteCommand),
 
     /// Download a blob to disk.
+    #[clap(name = "download")]
     Download(download::DownloadCommand),
 
     /// Push a file or directory to a menmos cluster.

--- a/bin/menmos-cli/src/cli/query.rs
+++ b/bin/menmos-cli/src/cli/query.rs
@@ -19,10 +19,7 @@ pub struct QueryCommand {
 
 impl QueryCommand {
     pub async fn run(self, cli: OutputManager, client: Client) -> Result<()> {
-        cli.step("Query");
-        service::query::execute(cli.push(), self.expression, self.from, self.size, client).await?;
-        cli.success("Done");
-
+        service::query::execute(cli, self.expression, self.from, self.size, client).await?;
         Ok(())
     }
 }

--- a/bin/menmos-cli/src/cli/query.rs
+++ b/bin/menmos-cli/src/cli/query.rs
@@ -15,11 +15,16 @@ pub struct QueryCommand {
     /// The maximum number of results to fetch.
     #[clap(long = "size", short = 's', default_value = "10")]
     size: usize,
+
+    /// Whether to enumerate all results .
+    #[clap(long = "all", short = 'a')]
+    all: bool,
 }
 
 impl QueryCommand {
     pub async fn run(self, cli: OutputManager, client: Client) -> Result<()> {
-        service::query::execute(cli, self.expression, self.from, self.size, client).await?;
+        service::query::execute(cli, self.expression, self.from, self.size, self.all, client)
+            .await?;
         Ok(())
     }
 }

--- a/bin/menmos-cli/src/main.rs
+++ b/bin/menmos-cli/src/main.rs
@@ -1,10 +1,28 @@
 mod cli;
 
+use anyhow::Result;
 use clap::Clap;
 use rood::cli::OutputManager;
 
+/// This should be called before calling any cli method or printing any output.
+/// See: https://github.com/rust-lang/rust/issues/46016
+pub fn reset_signal_pipe_handler() -> Result<()> {
+    #[cfg(target_family = "unix")]
+    {
+        use nix::sys::signal;
+
+        unsafe {
+            signal::signal(signal::Signal::SIGPIPE, signal::SigHandler::SigDfl)?;
+        }
+    }
+
+    Ok(())
+}
+
 #[tokio::main]
 async fn main() {
+    reset_signal_pipe_handler().unwrap();
+
     if let Err(e) = cli::Root::parse().run().await {
         OutputManager::new(false).error(&e.to_string());
     }

--- a/bin/menmos-cli/src/service/query.rs
+++ b/bin/menmos-cli/src/service/query.rs
@@ -1,30 +1,54 @@
 use anyhow::Result;
+use interface::QueryResponse;
 use menmos_client::{Client, Query};
 use rood::cli::OutputManager;
 
-pub async fn execute(
-    cli: OutputManager,
-    expression: Option<String>,
-    from: usize,
-    size: usize,
-    client: Client,
-) -> Result<()> {
-    let mut q = Query::default().with_from(from).with_size(size);
-
-    if let Some(expr) = expression {
-        q = q.with_expression(expr)?;
-    }
-
-    let resp = client.query(q).await?;
-
+fn output_results(resp: QueryResponse, cli: OutputManager) {
     let pushed = cli.push();
 
     for hit in resp.hits {
         cli.step(hit.id);
         pushed.debug(hit.url);
     }
+}
 
-    cli.debug(format!("{}/{} hits", resp.count, resp.total));
+pub async fn execute(
+    cli: OutputManager,
+    expression: Option<String>,
+    mut from: usize,
+    size: usize,
+    all: bool,
+    client: Client,
+) -> Result<()> {
+    let mut q = Query::default().with_from(from).with_size(size);
+    if let Some(expr) = expression {
+        q = q.with_expression(expr)?;
+    }
+
+    let resp = client.query(q.clone()).await?;
+
+    let mut count = resp.count;
+    let total = resp.total;
+
+    output_results(resp, cli.clone());
+    from += count;
+
+    if all {
+        loop {
+            let query = q.clone().with_from(from);
+            let resp = client.query(query.clone()).await?;
+            count += resp.count;
+            from += resp.count;
+
+            output_results(resp, cli.clone());
+
+            if count >= total {
+                break;
+            }
+        }
+    }
+
+    cli.debug(format!("{}/{} hits", count, total));
 
     Ok(())
 }

--- a/bin/menmos-cli/src/service/query.rs
+++ b/bin/menmos-cli/src/service/query.rs
@@ -17,9 +17,14 @@ pub async fn execute(
 
     let resp = client.query(q).await?;
 
+    let pushed = cli.push();
+
     for hit in resp.hits {
-        cli.step(hit.url);
+        cli.step(hit.id);
+        pushed.debug(hit.url);
     }
+
+    cli.debug(format!("{}/{} hits", resp.count, resp.total));
 
     Ok(())
 }

--- a/bin/menmos-fuse/src/menmos_fs/fs/common.rs
+++ b/bin/menmos-fuse/src/menmos_fs/fs/common.rs
@@ -1,5 +1,5 @@
-use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::{collections::HashMap, time::Instant};
 
 use anyhow::{anyhow, ensure, Result};
 
@@ -20,6 +20,8 @@ pub struct MenmosFS {
     pub(crate) blobid_to_inode: ConcurrentMap<String, u64>,
     pub(crate) inode_to_blobid: ConcurrentMap<u64, String>,
     pub(crate) name_to_blobid: ConcurrentMap<(u64, String), String>,
+
+    pub(crate) inode_to_last_refresh: ConcurrentMap<u64, Instant>,
 
     pub(crate) virtual_directories_inodes: ConcurrentMap<u64, VirtualDirectory>,
     pub(crate) virtual_directories: ConcurrentMap<(u64, String), u64>,
@@ -43,6 +45,8 @@ impl MenmosFS {
             inode_to_blobid: Default::default(),
             name_to_blobid: Default::default(),
             inode_counter: AtomicU64::new(3),
+
+            inode_to_last_refresh: ConcurrentMap::new(),
 
             virtual_directories_inodes: ConcurrentMap::new(),
             virtual_directories: Default::default(),

--- a/bin/menmos-fuse/src/menmos_fs/fs/release.rs
+++ b/bin/menmos-fuse/src/menmos_fs/fs/release.rs
@@ -3,7 +3,7 @@ use crate::MenmosFS;
 use super::{Error, Result};
 
 impl MenmosFS {
-    pub async fn release_impl(&self, ino: u64) -> Result<()> {
+    pub async fn release_impl(&self, ino: u64, is_writable: bool) -> Result<()> {
         log::info!("release i{}", ino);
         let mut buffers_guard = self.write_buffers.lock().await;
         if let Some(buffer) = buffers_guard.remove(&ino) {
@@ -17,13 +17,14 @@ impl MenmosFS {
             .await
             .ok_or(Error::NotFound)?;
 
-        // TODO: Don't call fsync if the file wasn't open for writing.
-        log::info!("calling fsync");
-        self.client.fsync(&blob_id).await.map_err(|e| {
-            log::error!("menmos fsync error: {}", e);
-            Error::IOError
-        })?;
-        log::info!("fsync complete");
+        if is_writable {
+            log::info!("start fsync {}", blob_id);
+            self.client.fsync(&blob_id).await.map_err(|e| {
+                log::error!("menmos fsync error: {}", e);
+                Error::IOError
+            })?;
+            log::info!("fsync {} complete", blob_id);
+        }
 
         Ok(())
     }


### PR DESCRIPTION
Fixes #31 

Commit log explains pretty well what changed.

tl;dr you can now fetch _all_ your work documents (via paging) by doing

```
$ mmos query work --all | mmos download ~/work_files
```