### PR TITLE
Add new auth flow and support new auth flow for the storage node only

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,6 +74,10 @@ checksum = "afddf7f520a80dbf76e6f50a35bca42a2331ef227a28b3b6dc5c2e2338d114b1"
 name = "apikit"
 version = "0.0.2-alpha.2"
 dependencies = [
+ "anyhow",
+ "bincode",
+ "branca",
+ "chrono",
  "log",
  "serde 1.0.123",
  "warp",

--- a/bin/amphora/src/amphora/config.rs
+++ b/bin/amphora/src/amphora/config.rs
@@ -63,7 +63,6 @@ pub struct NodeSetting {
     pub name: String,
     pub db_path: PathBuf,
     pub admin_password: String,
-    pub registration_secret: String,
     pub encryption_key: String,
 
     #[serde(default = "RedirectIP::default")]

--- a/bin/amphora/src/amphora/node/node_impl.rs
+++ b/bin/amphora/src/amphora/node/node_impl.rs
@@ -38,7 +38,7 @@ impl Storage {
     ) -> Result<Self> {
         let proxy = Arc::from(DirectoryProxy::new(
             &config.directory,
-            config.node.registration_secret.clone(),
+            &config.node.encryption_key,
         )?);
 
         let certificates = Arc::from(Mutex::from(certs));

--- a/bin/amphora/src/amphora/node/rebuild.rs
+++ b/bin/amphora/src/amphora/node/rebuild.rs
@@ -57,10 +57,7 @@ pub async fn execute(
 
     // Step 4 - Tell the directory that we're done pushing.
     proxy
-        .rebuild_complete(
-            &parameters.storage_node_name,
-            &parameters.directory_node_password,
-        )
+        .rebuild_complete(&parameters.storage_node_name)
         .await?;
 
     log::info!("rebuild complete");

--- a/bin/menmosd/src/menmosd/server/filters/admin.rs
+++ b/bin/menmosd/src/menmosd/server/filters/admin.rs
@@ -51,7 +51,9 @@ fn rebuild_complete(
     context: Context,
 ) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
     warp::delete()
-        .and(authenticated(context.config.node.admin_password.clone()))
+        .and(apikit::auth::storage_node(
+            context.config.node.encryption_key.clone(),
+        ))
         .and(with_context(context))
         .and(warp::path(REBUILD_PATH))
         .and(warp::path::param())

--- a/bin/menmosd/src/menmosd/server/filters/blobmeta.rs
+++ b/bin/menmosd/src/menmosd/server/filters/blobmeta.rs
@@ -22,13 +22,14 @@ fn create(
     context: Context,
 ) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
     warp::put()
+        .and(apikit::auth::storage_node(
+            context.config.node.encryption_key.clone(),
+        ))
         .and(with_context(context))
         .and(warp::path(BLOBS_PATH))
         .and(warp::path::param())
         .and(warp::path(METADATA_PATH))
         .and(warp::body::json())
-        .and(warp::header::<String>("x-storage-id"))
-        .and(warp::header::<String>("x-registration-secret"))
         .and_then(handlers::blobmeta::create)
 }
 

--- a/bin/menmosd/src/menmosd/server/filters/storage.rs
+++ b/bin/menmosd/src/menmosd/server/filters/storage.rs
@@ -23,8 +23,10 @@ fn put(
     warp::put()
         .and(warp::path(NODES_PATH))
         .and(warp::path(STORAGE_PATH))
+        .and(apikit::auth::storage_node(
+            context.config.node.encryption_key.clone(),
+        ))
         .and(util::with_context(context))
-        .and(warp::header::<String>("x-registration-secret"))
         .and(warp::body::json())
         .and_then(handlers::storage::put)
 }

--- a/bin/menmosd/src/menmosd/server/handlers/admin/rebuild_complete.rs
+++ b/bin/menmosd/src/menmosd/server/handlers/admin/rebuild_complete.rs
@@ -1,4 +1,5 @@
-use apikit::reject::InternalServerError;
+use apikit::auth::StorageNodeIdentity;
+use apikit::reject::{Forbidden, InternalServerError};
 
 use interface::message as msg;
 
@@ -7,9 +8,14 @@ use warp::reply;
 use crate::server::context::Context;
 
 pub async fn rebuild_complete(
+    identity: StorageNodeIdentity,
     context: Context,
     storage_node_id: String,
 ) -> Result<reply::Response, warp::Rejection> {
+    if identity.id != storage_node_id {
+        return Err(Forbidden.into());
+    }
+
     context
         .node
         .rebuild_complete(&storage_node_id)

--- a/bin/menmosd/src/menmosd/server/handlers/blobmeta/create.rs
+++ b/bin/menmosd/src/menmosd/server/handlers/blobmeta/create.rs
@@ -1,4 +1,5 @@
-use apikit::reject::{Forbidden, InternalServerError};
+use apikit::auth::StorageNodeIdentity;
+use apikit::reject::InternalServerError;
 
 use interface::message::MessageResponse;
 use interface::BlobMeta;
@@ -8,19 +9,14 @@ use warp::reply;
 use crate::server::Context;
 
 pub async fn create(
+    identity: StorageNodeIdentity,
     context: Context,
     blob_id: String,
     blob_meta: BlobMeta,
-    storage_node_id: String,
-    registration_secret: String,
 ) -> Result<reply::Response, warp::Rejection> {
-    if context.config.node.registration_secret != registration_secret {
-        return Err(warp::reject::custom(Forbidden));
-    }
-
     context
         .node
-        .index_blob(&blob_id, blob_meta, &storage_node_id)
+        .index_blob(&blob_id, blob_meta, &identity.id)
         .await
         .map_err(InternalServerError::from)?;
 

--- a/bin/menmosd/src/menmosd/server/handlers/storage/put.rs
+++ b/bin/menmosd/src/menmosd/server/handlers/storage/put.rs
@@ -10,12 +10,12 @@ use crate::server::context::Context;
 const MESSAGE_REGISTRATION_SUCCESSFUL: &str = "storage node registered";
 
 pub async fn put(
+    identity: apikit::auth::StorageNodeIdentity,
     context: Context,
-    registration_secret: String,
     info: StorageNodeInfo,
 ) -> Result<reply::Response, warp::Rejection> {
-    if context.config.node.registration_secret != registration_secret {
-        return Err(warp::reject::custom(Forbidden));
+    if identity.id != info.id {
+        return Err(Forbidden.into());
     }
 
     let node_resp = context

--- a/crates/apikit/Cargo.toml
+++ b/crates/apikit/Cargo.toml
@@ -8,6 +8,10 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+anyhow = "1"
+bincode = "1.3"
+branca = "0.10"
+chrono = "0.4"
 log = "0.4"
 serde = {version = "1", features = ["derive"]}
 warp = {version = "0.3", features = ["tls"]}

--- a/crates/apikit/src/auth.rs
+++ b/crates/apikit/src/auth.rs
@@ -1,4 +1,9 @@
-use warp::Filter;
+use branca::Branca;
+
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
+
+use warp::{filters::BoxedFilter, Filter};
 
 use crate::reject;
 
@@ -14,12 +19,100 @@ pub async fn validate_password<E: AsRef<str>, A: AsRef<str>>(
     }
 }
 
-pub fn authenticated(
-    expected_password: String,
+pub fn authenticated<S: Into<String>>(
+    expected_password: S,
 ) -> impl Filter<Extract = (), Error = warp::Rejection> + Clone {
+    let password: String = expected_password.into();
     warp::header::optional::<String>("authorization")
-        .and(warp::any().map(move || expected_password.clone()))
+        .and(warp::any().map(move || password.clone()))
         .and_then(validate_password)
         .and(warp::any())
         .untuple_one()
+}
+
+pub fn make_token<K: AsRef<str>, D: Serialize>(key: K, data: D) -> anyhow::Result<String> {
+    let mut token = Branca::new(key.as_ref().as_bytes())?;
+    token
+        .set_ttl(60 * 60 * 6)
+        .set_timestamp(chrono::Utc::now().timestamp() as u32);
+
+    let encoded_body = bincode::serialize(&data)?;
+    Ok(token.encode(&encoded_body)?)
+}
+
+#[derive(Deserialize, Serialize)]
+pub struct StorageNodeIdentity {
+    pub id: String,
+}
+
+impl StorageNodeIdentity {}
+
+#[derive(Deserialize, Serialize)]
+pub struct UserIdentity {
+    pub username: String,
+    pub admin: bool,
+    pub blobs_whitelist: Option<Vec<String>>, // If none, all blobs are allowed.
+}
+
+#[derive(Debug, Default, Deserialize, Serialize)]
+pub struct Signature {
+    pub signature: Option<String>,
+}
+
+fn optq<T: 'static + Default + Send + DeserializeOwned>() -> BoxedFilter<(T,)> {
+    warp::any()
+        .and(warp::query().or(warp::any().map(T::default)))
+        .unify()
+        .boxed()
+}
+
+fn extract_token<T, K>(key: K, token: String) -> Result<T, warp::Rejection>
+where
+    T: DeserializeOwned,
+    K: AsRef<str>,
+{
+    let token_decoder = Branca::new(key.as_ref().as_bytes()).map_err(|_| reject::Forbidden)?;
+
+    let decoded = token_decoder
+        .decode(&token, 60 * 60 * 6)
+        .map_err(|_| reject::Forbidden)?;
+
+    Ok(bincode::deserialize(&decoded).map_err(|_| reject::Forbidden)?)
+}
+
+async fn validate_user_tokens(
+    header_token: Option<String>,
+    url_signature_token: Option<String>,
+    key: String,
+) -> Result<UserIdentity, warp::Rejection> {
+    let token = header_token
+        .or(url_signature_token)
+        .ok_or(reject::Forbidden)?;
+
+    extract_token(&key, token)
+}
+
+pub fn user(
+    key: String,
+) -> impl Filter<Extract = (UserIdentity,), Error = warp::Rejection> + Clone {
+    warp::header::optional::<String>("authorization")
+        .and(optq::<Signature>().map(|s: Signature| s.signature))
+        .and(warp::any().map(move || key.clone()))
+        .and_then(validate_user_tokens)
+}
+
+async fn validate_storage_node_token(
+    token: Option<String>,
+    key: String,
+) -> Result<StorageNodeIdentity, warp::Rejection> {
+    let token = token.ok_or(reject::Forbidden)?;
+    extract_token(&key, token)
+}
+
+pub fn storage_node(
+    key: String,
+) -> impl Filter<Extract = (StorageNodeIdentity,), Error = warp::Rejection> + Clone {
+    warp::header::optional::<String>("authorization")
+        .and(warp::any().map(move || key.clone()))
+        .and_then(validate_storage_node_token)
 }


### PR DESCRIPTION
This PR adds a new auth flow (in `auth.rs` ) that will eventually replace all the auth we have.

This PR also implements said flow for storage node -> directory node communication _only_. 
This was a natural first step because storage nodes don't need the directory to issue them a token, since they themselves have the encryption key and thus can self-sign their tokens.

The next PR will add register + auth endpoints, the one after that will replace all existing authenticated routes with the new flow.

(vois tu comment je fais des efforts pour fragmenter les PRs? :wink: )