### PR TITLE
Add some docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,3 +128,8 @@ As mentioned in the setup section, if running in HTTPS mode, the menmosd server 
 Even though you can absolutely run a menmosd instance in the cloud along with a firewalled amphora that is not exposed to the internet, doing so might lead to some puzzling behavior for users of your cluster (e.g. some files disappearing from a directory when the user leaves the house because direct connection to the amphora is lost).
 
 If you do not want to expose your amphora to the public internet, we strongly recommend running your cluster through something like [Tailscale](https://tailscale.com/) - it's what we do too :)
+
+## Additional Documentation
+[CLI Reference](https://github.com/menmos/menmos/wiki/CLI-Reference)
+
+[Query Syntax](https://github.com/menmos/menmos/wiki/Query-Syntax)

--- a/bin/menmos-cli/src/service/config.rs
+++ b/bin/menmos-cli/src/service/config.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use menmos_client::profile::{Config, Profile};
+use menmos_client::{Config, Profile};
 use rood::cli::OutputManager;
 
 pub fn load_or_create(cli: OutputManager) -> Result<Config> {

--- a/crates/betterstreams/Cargo.toml
+++ b/crates/betterstreams/Cargo.toml
@@ -3,6 +3,7 @@ name = "betterstreams"
 version = "0.0.5-alpha.4"
 authors = ["William Dussault <dalloriam@gmail.com>"]
 edition = "2018"
+publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dev-dependencies]

--- a/crates/interface/src/directory.rs
+++ b/crates/interface/src/directory.rs
@@ -5,7 +5,7 @@ use anyhow::Result;
 
 use async_trait::async_trait;
 
-use rapidquery::Expression;
+pub use rapidquery::Expression;
 
 use serde::{Deserialize, Serialize};
 
@@ -32,12 +32,22 @@ pub struct FacetResponse {
     pub meta: HashMap<String, HashMap<String, u64>>,
 }
 
+/// The results of a query.
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct QueryResponse {
+    /// The number of hits returned with this response.
     pub count: usize,
+
+    /// The total number of hits.
     pub total: usize,
+
+    /// The query hits.
     pub hits: Vec<Hit>,
+
+    /// The facets computed for this query.
+    ///
+    /// Returned only if requested with the query.
     pub facets: Option<FacetResponse>,
 }
 
@@ -75,9 +85,11 @@ pub struct MetadataList {
     pub meta: HashMap<String, HashMap<String, usize>>,
 }
 
+/// A query that can be sent to a Menmos cluster.
 #[derive(Clone, Debug, Deserialize, Hash, Serialize, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
 pub struct Query {
+    /// The query expression.
     pub expression: Expression,
     pub from: usize,
     pub size: usize,

--- a/crates/interface/src/storage.rs
+++ b/crates/interface/src/storage.rs
@@ -14,6 +14,7 @@ use serde::{Deserialize, Serialize};
 
 use warp::hyper::body::Bytes;
 
+/// The type of a blob in a menmos cluster (file or directory).
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 pub enum Type {
     File,
@@ -43,14 +44,26 @@ impl CertificateInfo {
     }
 }
 
+/// Metadata associated with a blob.
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct BlobMeta {
+    /// The name of this blob. Does not need to be unique.
     pub name: String,
+
+    /// The type of this blob.
     pub blob_type: Type,
+
+    /// The key/value pairs for this blob.
     pub metadata: HashMap<String, String>,
+
+    /// The tags for this blob.
     pub tags: Vec<String>,
+
+    /// This blob's parent IDs.
     pub parents: Vec<String>,
+
+    /// This blob's size, in bytes.
     pub size: u64,
 }
 

--- a/crates/menmos-client/Cargo.toml
+++ b/crates/menmos-client/Cargo.toml
@@ -3,7 +3,6 @@ name = "menmos-client"
 version = "0.0.5-alpha.4"
 authors = ["William Dussault <dalloriam@gmail.com>"]
 edition = "2018"
-publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/menmos-client/src/client.rs
+++ b/crates/menmos-client/src/client.rs
@@ -140,7 +140,10 @@ impl Client {
 
     /// Create a new client from a configured profile with default settings.
     ///
-    /// The profiles are read from `$XDG_CONFIG_HOME/menmos/client.toml`
+    /// The profiles are read from
+    /// * `$XDG_CONFIG_HOME/menmos/client.toml` on Linux
+    /// * `~/Library/Application Support/menmos/client.toml` on MacOS
+    /// * `%APPDATA%\menmos\client.toml` on Windows
     pub async fn new_with_profile<S: Into<String>>(profile: S) -> Result<Self> {
         Self::new_with_params(Parameters {
             host_config: HostConfig::Profile {

--- a/crates/menmos-client/src/client.rs
+++ b/crates/menmos-client/src/client.rs
@@ -105,6 +105,7 @@ async fn extract<T: DeserializeOwned>(response: reqwest::Response) -> Result<T> 
     }
 }
 
+/// The client, used for interacting witn a Menmos cluster.
 #[derive(Clone)]
 pub struct Client {
     client: ReqwestClient,
@@ -117,7 +118,7 @@ pub struct Client {
 type Result<T> = std::result::Result<T, ClientError>;
 
 impl Client {
-    /// Create a new client with default settings.
+    /// Create a new client from explicit credentials with default settings.
     pub async fn new<S: Into<String>, U: Into<String>, P: Into<String>>(
         directory_host: S,
         username: U,
@@ -137,6 +138,9 @@ impl Client {
         .await
     }
 
+    /// Create a new client from a configured profile with default settings.
+    ///
+    /// The profiles are read from `$XDG_CONFIG_HOME/menmos/client.toml`
     pub async fn new_with_profile<S: Into<String>>(profile: S) -> Result<Self> {
         Self::new_with_params(Parameters {
             host_config: HostConfig::Profile {
@@ -150,6 +154,7 @@ impl Client {
         .await
     }
 
+    /// Get a client builder to get better control on how the client is configured.
     pub fn builder() -> ClientBuilder {
         ClientBuilder::default()
     }
@@ -315,6 +320,9 @@ impl Client {
         Ok(resp.token)
     }
 
+    /// Create an empty file on the cluster with the provided meta.
+    ///
+    /// Returns the created file's ID.
     pub async fn create_empty(&self, meta: BlobMeta) -> Result<String> {
         let url = format!("{}/blob", self.host);
         let meta_b64 = encode_metadata(meta)?;
@@ -381,6 +389,9 @@ impl Client {
         Ok(put_response.id)
     }
 
+    /// Send a health check request to the cluster.
+    ///
+    /// Returns the cluster health status as a string.
     pub async fn health(&self) -> Result<String> {
         let url = format!("{}/health", self.host);
 
@@ -398,6 +409,7 @@ impl Client {
         }
     }
 
+    /// List all storage nodes currently authenticated with the cluster.
     pub async fn list_storage_nodes(&self) -> Result<ListStorageNodesResponse> {
         let url = format!("{}/node/storage", self.host);
 
@@ -414,11 +426,17 @@ impl Client {
         extract_body(response).await
     }
 
+    /// Pushes a file with the specified meta to the cluster.
+    ///
+    /// Returns the ID of the created file.
     pub async fn push<P: AsRef<Path>>(&self, path: P, meta: BlobMeta) -> Result<String> {
         self.push_internal(path, meta, format!("{}/blob", self.host))
             .await
     }
 
+    /// Update a blob's content.
+    ///
+    /// Returns the ID of the updated file. Should always be equal to `blob_id`.
     pub async fn update_blob<P: AsRef<Path>>(
         &self,
         blob_id: &str,
@@ -429,6 +447,10 @@ impl Client {
             .await
     }
 
+    /// Lists all metadata values in the cluster.
+    ///
+    /// `tags` is an optional whitelist of tags to compute. When absent, all tags are included.
+    /// `meta_keys` is an optional whitelist of keys to compute. When absent, all key/value pairs are included (this can be very expensive).
     pub async fn list_meta(
         &self,
         tags: Option<Vec<String>>,
@@ -448,6 +470,7 @@ impl Client {
         extract(response).await
     }
 
+    /// Update a blob's metadata without touching the contents of the file.
     pub async fn update_meta(&self, blob_id: &str, meta: BlobMeta) -> Result<()> {
         let url = format!("{}/blob/{}/metadata", self.host, blob_id);
 
@@ -479,6 +502,9 @@ impl Client {
         }
     }
 
+    /// Force synchronization of a blob to its backing storage.
+    ///
+    /// This is an advanced feature, and should only be called by people who know what they are doing.
     pub async fn fsync(&self, blob_id: &str) -> Result<()> {
         let url = format!("{}/blob/{}/fsync", self.host, blob_id);
 
@@ -508,6 +534,7 @@ impl Client {
         }
     }
 
+    /// Write a byte buffer to a specified offset in a blob.
     pub async fn write(&self, blob_id: &str, offset: u64, buffer: Bytes) -> Result<()> {
         let url = format!("{}/blob/{}", self.host, blob_id);
 
@@ -550,6 +577,7 @@ impl Client {
         }
     }
 
+    /// Get a blob's metadata.
     pub async fn get_meta(&self, blob_id: &str) -> Result<Option<BlobMeta>> {
         let url = format!("{}/blob/{}/metadata", self.host, blob_id);
 
@@ -567,6 +595,7 @@ impl Client {
         Ok(resp.meta)
     }
 
+    /// Get a blob's body as a stream of bytes.
     pub async fn get_file(&self, blob_id: &str) -> Result<impl Stream<Item = Result<Bytes>>> {
         let url = format!("{}/blob/{}", self.host, blob_id);
 
@@ -602,6 +631,9 @@ impl Client {
     // TODO: Use a rust range instead of a tuple
     // TODO: Return a stream of Bytes buffers.
     // Note: range is end-inclusive here. TODO: Clarify when ranges are inclusive vs. exclusive.
+    /// Read a subset of a blob.
+    ///
+    /// The `range` argument is end-inclusive.
     pub async fn read_range(&self, blob_id: &str, range: (u64, u64)) -> Result<Vec<u8>> {
         let url = format!("{}/blob/{}", self.host, blob_id);
 
@@ -635,6 +667,7 @@ impl Client {
         }
     }
 
+    /// Send a query to the cluster.
     pub async fn query(&self, query: Query) -> Result<QueryResponse> {
         let url = format!("{}/query", self.host);
 
@@ -651,6 +684,7 @@ impl Client {
         extract(response).await
     }
 
+    /// Delete a blob from the cluster.
     pub async fn delete(&self, blob_id: String) -> Result<()> {
         let url = format!("{}/blob/{}", self.host, blob_id);
 

--- a/crates/menmos-client/src/lib.rs
+++ b/crates/menmos-client/src/lib.rs
@@ -1,14 +1,13 @@
 mod builder;
 mod client;
 mod parameters;
-pub mod profile;
+mod profile;
 
 use builder::ClientBuilder;
 use parameters::Parameters;
 
 pub use client::Client;
 pub use interface::BlobMeta as Meta;
-pub use interface::Query;
-pub use interface::QueryResponse;
 pub use interface::Type;
-pub use profile::Config;
+pub use interface::{Expression, Query, QueryResponse};
+pub use profile::{Config, Profile};

--- a/crates/menmos-client/src/profile.rs
+++ b/crates/menmos-client/src/profile.rs
@@ -33,6 +33,7 @@ fn get_config_path() -> Result<PathBuf> {
     Ok(cfg_dir_path.join("client").with_extension("toml"))
 }
 
+/// A client profile containing credentials to a menmos cluster.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Profile {
     pub host: String,
@@ -40,8 +41,10 @@ pub struct Profile {
     pub password: String,
 }
 
+/// A client configuration, as stored on disk.
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct Config {
+    /// The configuration profiles set by the user.
     pub profiles: HashMap<String, Profile>,
 }
 

--- a/crates/protocol/Cargo.toml
+++ b/crates/protocol/Cargo.toml
@@ -3,6 +3,7 @@ name = "protocol"
 version = "0.0.5-alpha.4"
 authors = ["William Dussault <dalloriam@gmail.com>"]
 edition = "2018"
+publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/testing/Cargo.toml
+++ b/crates/testing/Cargo.toml
@@ -3,6 +3,7 @@ name = "testing"
 version = "0.0.5-alpha.4"
 authors = ["William Dussault <dalloriam@gmail.com>"]
 edition = "2018"
+publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/xecute/Cargo.toml
+++ b/crates/xecute/Cargo.toml
@@ -3,6 +3,7 @@ name = "xecute"
 version = "0.0.5-alpha.4"
 authors = ["William Dussault <dalloriam@gmail.com>"]
 edition = "2018"
+publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/release.toml
+++ b/release.toml
@@ -1,4 +1,3 @@
 consolidate-commits = true
-disable-publish = true
 disable-tag = true
 tag-prefix = ""


### PR DESCRIPTION
This adds client docs + links to the wiki (which now hosts CLI docs & query syntax docs).

Fixes #17 

After that, we'll only need to publish menmos_client to crates.io and we'll be good for alpha :tada: 