### PR TITLE
[MEN-23] - A user can get/set/delete routing keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1477,6 +1477,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "menmos-std"
+version = "0.0.5"
+dependencies = [
+ "tokio",
+]
+
+[[package]]
 name = "menmos-testing"
 version = "0.0.5"
 dependencies = [
@@ -1535,6 +1542,7 @@ dependencies = [
  "menmos-indexer",
  "menmos-interface",
  "menmos-protocol",
+ "menmos-std",
  "menmos-testing",
  "menmos-xecute",
  "mime",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
     "crates/menmos-interface",
     "crates/menmos-protocol",
     "crates/menmos-repository",
+    "crates/menmos-std",
     "crates/menmos-testing",
     "crates/menmos-xecute",
     "crates/rapidquery",
@@ -27,6 +28,7 @@ menmos-indexer = { path = 'crates/menmos-indexer' }
 menmos-interface = { path = 'crates/menmos-interface' }
 menmos-protocol = { path = 'crates/menmos-protocol' }
 menmos-repository = { path = 'crates/menmos-repository' }
+menmos-std = { path = 'crates/menmos-std' }
 menmos-testing = { path = 'crates/menmos-testing' }
 menmos-xecute = { path = 'crates/menmos-xecute' }
 rapidquery = { path = 'crates/rapidquery' }

--- a/bin/menmosd/Cargo.toml
+++ b/bin/menmosd/Cargo.toml
@@ -47,6 +47,7 @@ menmos-apikit = "0.0.5"
 menmos-indexer = { path = "../../crates/menmos-indexer"}
 menmos-interface = "0.0.5"
 menmos-protocol = "0.0.5"
+menmos-std = {version = "0.0.5", features = ["async"]}
 menmos-xecute = "0.0.5"
 mime = "0.3"
 rapidquery = {version = "0.0.5", features=["bitvec_span"]}

--- a/bin/menmosd/src/menmosd/node/mod.rs
+++ b/bin/menmosd/src/menmosd/node/mod.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 use indexer::Index;
 
 mod node_impl;
+mod routing;
 
 pub use node_impl::Directory;
 

--- a/bin/menmosd/src/menmosd/node/routing/mod.rs
+++ b/bin/menmosd/src/menmosd/node/routing/mod.rs
@@ -1,0 +1,3 @@
+mod router;
+
+pub use router::NodeRouter;

--- a/bin/menmosd/src/menmosd/node/routing/router.rs
+++ b/bin/menmosd/src/menmosd/node/routing/router.rs
@@ -1,0 +1,109 @@
+use std::sync::Arc;
+
+use anyhow::{anyhow, Result};
+
+use chrono::{DateTime, Duration, Utc};
+
+use indexer::iface::RoutingMapper;
+use interface::{BlobMetaRequest, StorageNodeInfo};
+
+use menmos_std::collections::{AsyncHashMap, AsyncList};
+
+const NODE_FORGET_DURATION_SECONDS: i64 = 60;
+
+pub struct NodeRouter<I>
+where
+    I: RoutingMapper + Send + Sync,
+{
+    storage_nodes: AsyncHashMap<String, (StorageNodeInfo, DateTime<Utc>)>,
+    round_robin: AsyncList<String>,
+
+    node_forget_duration: Duration,
+
+    index: Arc<I>,
+}
+
+impl<I> NodeRouter<I>
+where
+    I: RoutingMapper + Send + Sync,
+{
+    pub fn new(index: Arc<I>) -> Self {
+        Self {
+            storage_nodes: AsyncHashMap::new(),
+            round_robin: Default::default(),
+            node_forget_duration: Duration::seconds(NODE_FORGET_DURATION_SECONDS),
+            index,
+        }
+    }
+
+    async fn prune_last_node(&self) {
+        if let Some(node_id) = self.round_robin.pop_back().await {
+            self.storage_nodes.remove(&node_id).await;
+        } else {
+            log::warn!("called pruned_last_node with an empty node list");
+        }
+    }
+
+    async fn get_node_if_fresh(&self, node_id: &str) -> Option<StorageNodeInfo> {
+        if let Some((node_info, seen_at)) = self.storage_nodes.get(node_id).await {
+            if Utc::now() - seen_at > self.node_forget_duration {
+                // Node is expired.
+                None
+            } else {
+                Some(node_info)
+            }
+        } else {
+            // Node doesn't exist.
+            None
+        }
+    }
+
+    pub async fn add_node(&self, storage_node: StorageNodeInfo) {
+        let node_id = storage_node.id.clone();
+
+        let already_existed = self
+            .storage_nodes
+            .insert(storage_node.id.clone(), (storage_node, chrono::Utc::now()))
+            .await
+            .is_some();
+
+        if !already_existed {
+            self.round_robin.push_back(node_id).await;
+        }
+    }
+
+    pub async fn get_node(&self, node_id: &str) -> Option<StorageNodeInfo> {
+        self.get_node_if_fresh(node_id).await
+    }
+
+    pub async fn list_nodes(&self) -> Vec<StorageNodeInfo> {
+        self.storage_nodes
+            .get_all()
+            .await
+            .into_iter()
+            .map(|(_k, (node_info, _last_seen))| node_info)
+            .collect()
+    }
+
+    pub async fn route_blob(
+        &self,
+        _blob_id: &str,
+        _meta_request: &BlobMetaRequest,
+    ) -> Result<StorageNodeInfo> {
+        loop {
+            let node_id = self
+                .round_robin
+                .pop_front()
+                .await
+                .ok_or_else(|| anyhow!("no storage node defined"))?;
+
+            self.round_robin.push_back(node_id.clone()).await;
+
+            if let Some(node) = self.get_node_if_fresh(&node_id).await {
+                return Ok(node);
+            } else {
+                self.prune_last_node().await;
+            }
+        }
+    }
+}

--- a/bin/menmosd/src/menmosd/node/test/node.rs
+++ b/bin/menmosd/src/menmosd/node/test/node.rs
@@ -494,3 +494,20 @@ async fn facet_grouping() -> Result<()> {
 
     Ok(())
 }
+
+#[tokio::test]
+async fn routing_key_get_set_delete() -> Result<()> {
+    let node = TestDirNode::new(MockIndex::default());
+
+    assert_eq!(node.get_routing_key("jdoe").await?, None);
+
+    node.set_routing_key("jdoe", "some_field").await?;
+
+    assert_eq!(node.get_routing_key("jdoe").await?.unwrap(), "some_field");
+
+    node.delete_routing_key("jdoe").await?;
+
+    assert_eq!(node.get_routing_key("jdoe").await?, None);
+
+    Ok(())
+}

--- a/bin/menmosd/src/menmosd/server/filters/mod.rs
+++ b/bin/menmosd/src/menmosd/server/filters/mod.rs
@@ -3,6 +3,7 @@ mod auth;
 mod blob;
 mod blobmeta;
 mod query;
+mod routing;
 mod storage;
 mod util;
 
@@ -20,7 +21,8 @@ pub fn all(
         .or(blobmeta::all(context.clone()))
         .or(admin::all(context.clone()))
         .or(query::all(context.clone()))
-        .or(auth::all(context))
+        .or(auth::all(context.clone()))
+        .or(routing::all(context))
         .recover(apikit::reject::recover)
         .with(warp::log("directory::api"))
 }

--- a/bin/menmosd/src/menmosd/server/filters/routing.rs
+++ b/bin/menmosd/src/menmosd/server/filters/routing.rs
@@ -1,0 +1,55 @@
+use warp::Filter;
+
+use crate::server::{handlers, Context};
+
+use super::util::with_context;
+
+const ROUTING_PATH: &str = "routing";
+
+pub fn all(
+    context: Context,
+) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
+    get(context.clone())
+        .or(set(context.clone()))
+        .or(delete(context))
+}
+
+fn get(
+    context: Context,
+) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
+    warp::get()
+        .and(apikit::auth::user(
+            context.config.node.encryption_key.clone(),
+        ))
+        .and(with_context(context))
+        .and(warp::path(ROUTING_PATH))
+        .and(warp::path::end())
+        .and_then(handlers::routing::get_key)
+}
+
+fn set(
+    context: Context,
+) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
+    warp::put()
+        .and(apikit::auth::user(
+            context.config.node.encryption_key.clone(),
+        ))
+        .and(with_context(context))
+        .and(warp::path(ROUTING_PATH))
+        .and(warp::path::end())
+        .and(warp::body::json())
+        .and_then(handlers::routing::set_key)
+}
+
+fn delete(
+    context: Context,
+) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
+    warp::delete()
+        .and(apikit::auth::user(
+            context.config.node.encryption_key.clone(),
+        ))
+        .and(with_context(context))
+        .and(warp::path(ROUTING_PATH))
+        .and(warp::path::end())
+        .and_then(handlers::routing::delete_key)
+}

--- a/bin/menmosd/src/menmosd/server/handlers/mod.rs
+++ b/bin/menmosd/src/menmosd/server/handlers/mod.rs
@@ -3,4 +3,5 @@ pub mod auth;
 pub mod blob;
 pub mod blobmeta;
 pub mod query;
+pub mod routing;
 pub mod storage;

--- a/bin/menmosd/src/menmosd/server/handlers/routing/delete.rs
+++ b/bin/menmosd/src/menmosd/server/handlers/routing/delete.rs
@@ -1,0 +1,19 @@
+use apikit::auth::UserIdentity;
+use apikit::reject::InternalServerError;
+
+use warp::reply;
+
+use crate::server::context::Context;
+
+pub async fn delete_key(
+    user: UserIdentity,
+    context: Context,
+) -> Result<reply::Response, warp::Rejection> {
+    context
+        .node
+        .delete_routing_key(&user.username)
+        .await
+        .map_err(InternalServerError::from)?;
+
+    Ok(apikit::reply::message("ok"))
+}

--- a/bin/menmosd/src/menmosd/server/handlers/routing/get.rs
+++ b/bin/menmosd/src/menmosd/server/handlers/routing/get.rs
@@ -1,0 +1,19 @@
+use apikit::auth::UserIdentity;
+use apikit::reject::InternalServerError;
+
+use protocol::directory::routing::GetRoutingKeyResponse;
+use warp::reply;
+
+use crate::server::context::Context;
+
+pub async fn get_key(
+    user: UserIdentity,
+    context: Context,
+) -> Result<reply::Response, warp::Rejection> {
+    let routing_key = context
+        .node
+        .get_routing_key(&user.username)
+        .await
+        .map_err(InternalServerError::from)?;
+    Ok(apikit::reply::json(&GetRoutingKeyResponse { routing_key }))
+}

--- a/bin/menmosd/src/menmosd/server/handlers/routing/mod.rs
+++ b/bin/menmosd/src/menmosd/server/handlers/routing/mod.rs
@@ -1,0 +1,7 @@
+mod delete;
+mod get;
+mod set;
+
+pub use delete::delete_key;
+pub use get::get_key;
+pub use set::set_key;

--- a/bin/menmosd/src/menmosd/server/handlers/routing/set.rs
+++ b/bin/menmosd/src/menmosd/server/handlers/routing/set.rs
@@ -1,0 +1,22 @@
+use apikit::auth::UserIdentity;
+use apikit::reject::InternalServerError;
+
+use protocol::directory::routing::SetRoutingKeyRequest;
+
+use warp::reply;
+
+use crate::server::context::Context;
+
+pub async fn set_key(
+    user: UserIdentity,
+    context: Context,
+    request: SetRoutingKeyRequest,
+) -> Result<reply::Response, warp::Rejection> {
+    context
+        .node
+        .set_routing_key(&user.username, &request.routing_key)
+        .await
+        .map_err(InternalServerError::from)?;
+
+    Ok(apikit::reply::message("ok"))
+}

--- a/bin/menmosd/tests/menmosd_routing.rs
+++ b/bin/menmosd/tests/menmosd_routing.rs
@@ -1,0 +1,33 @@
+//! Test blob routing.
+use anyhow::Result;
+use menmos_client::Client;
+use testing::fixtures::Menmos;
+
+#[tokio::test]
+async fn get_set_delete_routing_key() -> Result<()> {
+    let cluster = Menmos::new().await?;
+
+    // Key doesn't exist in the beginning.
+    let response = cluster.client.get_routing_key().await?;
+    assert_eq!(response.routing_key, None);
+
+    cluster.client.set_routing_key("some_field").await?;
+
+    // Key exists afterwards.
+    let response = cluster.client.get_routing_key().await?;
+    assert_eq!(response.routing_key, Some(String::from("some_field")));
+
+    // Other user doesn't see the routing key.
+    cluster.add_user("john", "bingbong").await?;
+    let john_client = Client::new(&cluster.directory_url, "john", "bingbong").await?;
+    let response = john_client.get_routing_key().await?;
+    assert_eq!(response.routing_key, None);
+
+    // Deleting the key works.
+    cluster.client.delete_routing_key().await?;
+    let response = cluster.client.get_routing_key().await?;
+    assert_eq!(response.routing_key, None);
+
+    cluster.stop_all().await?;
+    Ok(())
+}

--- a/crates/menmos-client/src/client.rs
+++ b/crates/menmos-client/src/client.rs
@@ -18,6 +18,7 @@ use protocol::{
     directory::{
         auth::{LoginRequest, LoginResponse, RegisterRequest},
         blobmeta::{GetMetaResponse, ListMetadataRequest},
+        routing::{GetRoutingKeyResponse, SetRoutingKeyRequest},
         storage::ListStorageNodesResponse,
     },
     storage::PutResponse,
@@ -719,6 +720,65 @@ impl Client {
         } else {
             // An error occurred.
             return Err(extract_error(response).await);
+        }
+    }
+
+    pub async fn get_routing_key(&self) -> Result<GetRoutingKeyResponse> {
+        let url = format!("{}/routing", self.host);
+
+        let response = self
+            .execute(|| {
+                self.client
+                    .get(&url)
+                    .bearer_auth(&self.token)
+                    .build()
+                    .context(RequestBuildError)
+            })
+            .await?;
+
+        extract(response).await
+    }
+
+    pub async fn set_routing_key(&self, routing_key: &str) -> Result<()> {
+        let url = format!("{}/routing", self.host);
+
+        let response = self
+            .execute(|| {
+                self.client
+                    .put(&url)
+                    .bearer_auth(&self.token)
+                    .json(&SetRoutingKeyRequest {
+                        routing_key: String::from(routing_key),
+                    })
+                    .build()
+                    .context(RequestBuildError)
+            })
+            .await?;
+
+        if response.status().is_success() {
+            Ok(())
+        } else {
+            Err(extract_error(response).await)
+        }
+    }
+
+    pub async fn delete_routing_key(&self) -> Result<()> {
+        let url = format!("{}/routing", self.host);
+
+        let response = self
+            .execute(|| {
+                self.client
+                    .delete(&url)
+                    .bearer_auth(&self.token)
+                    .build()
+                    .context(RequestBuildError)
+            })
+            .await?;
+
+        if response.status().is_success() {
+            Ok(())
+        } else {
+            Err(extract_error(response).await)
         }
     }
 }

--- a/crates/menmos-indexer/src/lib.rs
+++ b/crates/menmos-indexer/src/lib.rs
@@ -3,6 +3,7 @@ mod documents;
 pub mod iface;
 mod meta;
 mod root;
+mod routing;
 mod storage;
 mod users;
 

--- a/crates/menmos-indexer/src/routing.rs
+++ b/crates/menmos-indexer/src/routing.rs
@@ -1,0 +1,46 @@
+use anyhow::Result;
+
+use async_trait::async_trait;
+
+use crate::iface::{Flush, RoutingMapper};
+
+const ROUTING_KEY_MAP: &str = "routing_keys";
+
+pub struct RoutingStore {
+    routing_keys: sled::Tree,
+}
+
+impl RoutingStore {
+    pub fn new(db: &sled::Db) -> Result<Self> {
+        let routing_keys = db.open_tree(ROUTING_KEY_MAP)?;
+        Ok(Self { routing_keys })
+    }
+}
+
+#[async_trait]
+impl Flush for RoutingStore {
+    async fn flush(&self) -> Result<()> {
+        self.routing_keys.flush_async().await?;
+        Ok(())
+    }
+}
+
+impl RoutingMapper for RoutingStore {
+    fn get_routing_key(&self, username: &str) -> Result<Option<String>> {
+        Ok(self
+            .routing_keys
+            .get(username.as_bytes())?
+            .map(|key_ivec| String::from_utf8_lossy(key_ivec.as_ref()).to_string()))
+    }
+
+    fn set_routing_key(&self, username: &str, routing_key: &str) -> Result<()> {
+        self.routing_keys
+            .insert(username.as_bytes(), routing_key.as_bytes())?;
+        Ok(())
+    }
+
+    fn delete_routing_key(&self, username: &str) -> Result<()> {
+        self.routing_keys.remove(username.as_bytes())?;
+        Ok(())
+    }
+}

--- a/crates/menmos-indexer/src/storage.rs
+++ b/crates/menmos-indexer/src/storage.rs
@@ -1,29 +1,18 @@
-use std::collections::HashMap;
-use std::sync::RwLock;
-
-use anyhow::{anyhow, Result};
+use anyhow::Result;
 
 use async_trait::async_trait;
-
-use chrono::{DateTime, Utc};
-
-use interface::StorageNodeInfo;
 
 use crate::iface::{Flush, StorageNodeMapper};
 
 const DISPATCH_TREE: &str = "dispatch";
 pub struct StorageDispatch {
     tree: sled::Tree,
-    nodes: RwLock<HashMap<String, (StorageNodeInfo, DateTime<Utc>)>>,
 }
 
 impl StorageDispatch {
     pub fn new(db: &sled::Db) -> Result<Self> {
         let tree = db.open_tree(DISPATCH_TREE)?;
-        Ok(Self {
-            tree,
-            nodes: Default::default(),
-        })
+        Ok(Self { tree })
     }
 }
 
@@ -36,39 +25,6 @@ impl Flush for StorageDispatch {
 }
 
 impl StorageNodeMapper for StorageDispatch {
-    fn get_node(&self, node_id: &str) -> Result<Option<(StorageNodeInfo, chrono::DateTime<Utc>)>> {
-        let map_guard = self.nodes.write().map_err(|_| anyhow!("poisoned mutex"))?;
-        let nodes = &*map_guard;
-        match nodes.get(node_id) {
-            Some((s, seen_at)) => Ok(Some((s.clone(), *seen_at))),
-            None => Ok(None),
-        }
-    }
-
-    fn get_all_nodes(&self) -> Result<Vec<StorageNodeInfo>> {
-        let map_guard = self.nodes.write().map_err(|_| anyhow!("poisoned mutex"))?;
-        let nodes = &*map_guard;
-
-        Ok(nodes
-            .iter()
-            .map(|(_k, (node_info, _last_seen))| node_info.clone())
-            .collect())
-    }
-
-    fn write_node(&self, info: StorageNodeInfo, seen_at: chrono::DateTime<Utc>) -> Result<bool> {
-        let mut map_guard = self.nodes.write().map_err(|_| anyhow!("poisoned mutex"))?;
-        let nodes = &mut *map_guard;
-        let was_set = nodes.insert(info.id.clone(), (info, seen_at)).is_some();
-        Ok(was_set)
-    }
-
-    fn delete_node(&self, node_id: &str) -> Result<()> {
-        let mut map_guard = self.nodes.write().map_err(|_| anyhow!("poisoned mutex"))?;
-        let nodes = &mut *map_guard;
-        nodes.remove(node_id);
-        Ok(())
-    }
-
     fn get_node_for_blob(&self, blob_id: &str) -> Result<Option<String>> {
         Ok(self
             .tree

--- a/crates/menmos-indexer/src/test/mod.rs
+++ b/crates/menmos-indexer/src/test/mod.rs
@@ -1,5 +1,6 @@
 mod bitvec_tree;
 mod document;
 mod meta;
+mod routing;
 mod storage;
 mod users;

--- a/crates/menmos-indexer/src/test/routing.rs
+++ b/crates/menmos-indexer/src/test/routing.rs
@@ -1,0 +1,58 @@
+use anyhow::Result;
+use tempfile::TempDir;
+
+use crate::{iface::RoutingMapper, routing::RoutingStore};
+
+#[test]
+fn init_doesnt_fail() -> Result<()> {
+    let d = TempDir::new()?;
+    let db = sled::open(d.path())?;
+    let _r = RoutingStore::new(&db)?;
+    Ok(())
+}
+
+#[test]
+fn get_routing_key_with_no_key_returns_none() -> Result<()> {
+    let d = TempDir::new()?;
+    let db = sled::open(d.path())?;
+    let r = RoutingStore::new(&db)?;
+    assert_eq!(r.get_routing_key("bing")?, None);
+
+    Ok(())
+}
+
+#[test]
+fn set_routing_key_works() -> Result<()> {
+    let d = TempDir::new()?;
+    let db = sled::open(d.path())?;
+    let r = RoutingStore::new(&db)?;
+    r.set_routing_key("jdoe", "some_field")?;
+    assert_eq!(r.get_routing_key("jdoe")?.unwrap(), "some_field");
+
+    Ok(())
+}
+
+#[test]
+fn delete_routing_key_works() -> Result<()> {
+    let d = TempDir::new()?;
+    let db = sled::open(d.path())?;
+    let r = RoutingStore::new(&db)?;
+
+    r.set_routing_key("jdoe", "some_field")?;
+    r.delete_routing_key("jdoe")?;
+
+    assert_eq!(r.get_routing_key("jdoe")?, None);
+
+    Ok(())
+}
+
+#[test]
+fn delete_nonexistent_routing_key_doesnt_fail() -> Result<()> {
+    let d = TempDir::new()?;
+    let db = sled::open(d.path())?;
+    let r = RoutingStore::new(&db)?;
+
+    r.delete_routing_key("i dont exist")?;
+
+    Ok(())
+}

--- a/crates/menmos-indexer/src/test/storage.rs
+++ b/crates/menmos-indexer/src/test/storage.rs
@@ -1,8 +1,5 @@
-use std::net::IpAddr;
-
 use anyhow::Result;
 
-use interface::StorageNodeInfo;
 use tempfile::TempDir;
 
 use crate::{iface::StorageNodeMapper, storage::StorageDispatch};
@@ -68,32 +65,6 @@ fn reload_keeps_mapping() {
     let s = StorageDispatch::new(&db).unwrap();
 
     assert_eq!(s.get_node_for_blob("a").unwrap().unwrap(), "b");
-}
-
-#[test]
-fn get_set_storage_node() -> Result<()> {
-    let d = TempDir::new()?;
-    let db = sled::open(d.path())?;
-    let s = StorageDispatch::new(&db)?;
-
-    let node_info = StorageNodeInfo {
-        id: String::from("bing"),
-        redirect_info: interface::RedirectInfo::Static {
-            static_address: IpAddr::from([192, 168, 2, 1]),
-        },
-        port: 3031,
-    };
-
-    let now = chrono::Utc::now();
-
-    s.write_node(node_info.clone(), now.clone())?;
-
-    let (n_info, timestamp) = s.get_node("bing")?.unwrap();
-
-    assert_eq!(n_info, node_info);
-    assert_eq!(timestamp.timestamp(), now.timestamp()); // We're losing nanoseconds in the serialization, which is acceptable.
-
-    Ok(())
 }
 
 #[test]

--- a/crates/menmos-interface/src/directory.rs
+++ b/crates/menmos-interface/src/directory.rs
@@ -169,6 +169,10 @@ pub trait DirectoryNode {
     async fn index_blob(&self, blob_id: &str, meta: BlobInfo, storage_node_id: &str) -> Result<()>;
     async fn delete_blob(&self, blob_id: &str, username: &str) -> Result<Option<StorageNodeInfo>>;
 
+    async fn get_routing_key(&self, user: &str) -> Result<Option<String>>;
+    async fn set_routing_key(&self, user: &str, routing_key: &str) -> Result<()>;
+    async fn delete_routing_key(&self, user: &str) -> Result<()>;
+
     async fn register_storage_node(&self, def: StorageNodeInfo) -> Result<StorageNodeResponseData>;
     async fn get_blob_storage_node(&self, blob_id: &str) -> Result<Option<StorageNodeInfo>>;
 

--- a/crates/menmos-protocol/src/directory.rs
+++ b/crates/menmos-protocol/src/directory.rs
@@ -26,6 +26,24 @@ pub mod blobmeta {
     }
 }
 
+pub mod routing {
+    use super::*;
+
+    #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+    #[serde(deny_unknown_fields)]
+    pub struct GetRoutingKeyResponse {
+        /// The field name to use for routing.
+        pub routing_key: Option<String>,
+    }
+
+    #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+    #[serde(deny_unknown_fields)]
+    pub struct SetRoutingKeyRequest {
+        /// The field name to use for routing.
+        pub routing_key: String,
+    }
+}
+
 pub mod auth {
     use super::*;
 

--- a/crates/menmos-std/Cargo.toml
+++ b/crates/menmos-std/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 [features]
 default = []
 
-async = []
+async = ["tokio"]
 
 [dependencies]
-tokio = {version = "1.2", features = ["full"]} # optional = true}
+tokio = {version = "1.2", features = ["full"], optional = true}

--- a/crates/menmos-std/Cargo.toml
+++ b/crates/menmos-std/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "menmos-std"
+version = "0.0.5"
+authors = ["William Dussault <dalloriam@gmail.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[features]
+default = []
+
+async = []
+
+[dependencies]
+tokio = {version = "1.2", features = ["full"]} # optional = true}

--- a/crates/menmos-std/src/collections/async_list.rs
+++ b/crates/menmos-std/src/collections/async_list.rs
@@ -1,0 +1,40 @@
+use std::collections::LinkedList;
+
+use tokio::sync::Mutex;
+
+#[derive(Debug, Default)]
+pub struct AsyncList<T> {
+    data: Mutex<LinkedList<T>>,
+}
+
+impl<T> AsyncList<T> {
+    pub async fn pop_front(&self) -> Option<T> {
+        let mut guard = self.data.lock().await;
+        guard.pop_front()
+    }
+
+    pub async fn pop_back(&self) -> Option<T> {
+        let mut guard = self.data.lock().await;
+        guard.pop_back()
+    }
+
+    pub async fn push_front(&self, v: T) {
+        let mut guard = self.data.lock().await;
+        guard.push_front(v)
+    }
+
+    pub async fn push_back(&self, v: T) {
+        let mut guard = self.data.lock().await;
+        guard.push_back(v)
+    }
+}
+
+impl<T> AsyncList<T>
+where
+    T: Clone,
+{
+    pub async fn get_all(&self) -> Vec<T> {
+        let guard = self.data.lock().await;
+        guard.iter().cloned().collect()
+    }
+}

--- a/crates/menmos-std/src/collections/async_map.rs
+++ b/crates/menmos-std/src/collections/async_map.rs
@@ -1,0 +1,88 @@
+use std::hash::Hash;
+use std::{borrow::Borrow, collections::HashMap};
+
+use tokio::sync::RwLock;
+
+#[derive(Debug, Default)]
+pub struct AsyncHashMap<K, V>
+where
+    K: Eq + Hash,
+    V: Clone,
+{
+    data: RwLock<HashMap<K, V>>,
+}
+
+impl<K, V> AsyncHashMap<K, V>
+where
+    K: Eq + Hash + Clone,
+    V: Clone,
+{
+    pub fn new() -> Self {
+        Self {
+            data: Default::default(),
+        }
+    }
+
+    pub async fn reserve(&self, additional: usize) {
+        let mut guard = self.data.write().await;
+        guard.reserve(additional);
+    }
+
+    pub async fn len(&self) -> usize {
+        let guard = self.data.read().await;
+        guard.len()
+    }
+
+    pub async fn is_empty(&self) -> bool {
+        let guard = self.data.read().await;
+        guard.is_empty()
+    }
+
+    pub async fn clear(&self) {
+        let mut guard = self.data.write().await;
+        guard.clear();
+    }
+
+    pub async fn get<Q: ?Sized>(&self, k: &Q) -> Option<V>
+    where
+        K: Borrow<Q>,
+        Q: Hash + Eq,
+    {
+        let guard = self.data.read().await;
+        guard.get(k).cloned()
+    }
+
+    pub async fn get_all(&self) -> Vec<(K, V)> {
+        let guard = self.data.read().await;
+        let mut data = Vec::with_capacity(guard.len());
+
+        for (key, value) in guard.iter() {
+            data.push((key.clone(), value.clone()));
+        }
+
+        data
+    }
+
+    pub async fn contains_key<Q: ?Sized>(&self, k: &Q) -> bool
+    where
+        K: Borrow<Q>,
+        Q: Hash + Eq,
+    {
+        let guard = self.data.read().await;
+        guard.contains_key(k)
+    }
+
+    pub async fn insert(&self, k: K, v: V) -> Option<V> {
+        let mut guard = self.data.write().await;
+        guard.insert(k, v)
+    }
+
+    pub async fn remove<Q: ?Sized>(&self, k: &Q) -> Option<V>
+    where
+        K: Borrow<Q>,
+        Q: Hash + Eq,
+    {
+        let mut guard = self.data.write().await;
+        guard.remove(k)
+    }
+}

--- a/crates/menmos-std/src/collections/mod.rs
+++ b/crates/menmos-std/src/collections/mod.rs
@@ -1,0 +1,5 @@
+mod async_list;
+mod async_map;
+
+pub use async_list::AsyncList;
+pub use async_map::AsyncHashMap;

--- a/crates/menmos-std/src/lib.rs
+++ b/crates/menmos-std/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod collections;


### PR DESCRIPTION
tl;dr:
* new crate `menmos-std` for general-purpose datastructures & utilities
  * contains `AsyncList` and `AsyncHashMap` for now
* removed storage node persistence from the index
* added a `NodeRouter` that will be in charge of using the routing keys (for now the node router contains the old round-robin logic)
* added CRUD endpoints for managing routing keys
* added unit, integration & functional tests for the feature