### PR TITLE
Fix Clippy Lints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,7 @@ on:
     branches:
     - master
   pull_request:
-    branches:
-      - '*'
+    types: [opened, synchronize]
 
 jobs:
   unit:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,8 @@ on:
     branches:
     - master
   pull_request:
-    branches: {}
+    branches:
+      - '*'
 
 jobs:
   unit:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,7 @@ on:
     branches:
     - master
   pull_request:
-    branches:
-    - master
+    branches: {}
 
 jobs:
   unit:

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ __Note:__ When running menmosd in HTTPS mode, the server will most likely need e
 # config_http.toml
 
 [server]
-type = "HTTP"
+type = "http"
 port = 3030
 
 [node]
@@ -75,7 +75,7 @@ encryption_key = "<encryption key>" # The encryption key *must* be exactly 32 ch
 
 # The HTTPS server listens by default on ports 53 (for DNS) and 443.
 [server]
-type = "HTTPS"
+type = "https"
 letsencrypt_email = "hello@menmos.xyz" # The email to use for you letsencrypt account.
 certificate_storage_path = "./certificates" # The directory in which to store your certificates.
 

--- a/bin/amphora/src/amphora/config.rs
+++ b/bin/amphora/src/amphora/config.rs
@@ -21,14 +21,14 @@ const DEFAULT_KEY_LOCKS_LIFETIME_SECONDS: i64 = 60 * 15; // 15 minutes.
 /// node decide which IP to use.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
-pub enum RedirectIP {
+pub enum RedirectIp {
     Automatic,
     Static(IpAddr),
 }
 
-impl Default for RedirectIP {
+impl Default for RedirectIp {
     fn default() -> Self {
-        RedirectIP::Automatic
+        RedirectIp::Automatic
     }
 }
 
@@ -64,8 +64,8 @@ pub struct NodeSetting {
     pub db_path: PathBuf,
     pub encryption_key: String,
 
-    #[serde(default = "RedirectIP::default")]
-    pub redirect_ip: RedirectIP,
+    #[serde(default = "RedirectIp::default")]
+    pub redirect_ip: RedirectIp,
 
     pub blob_storage: BlobStorageImpl,
 

--- a/bin/amphora/src/amphora/node/node_info.rs
+++ b/bin/amphora/src/amphora/node/node_info.rs
@@ -6,16 +6,16 @@ use interface::StorageNodeInfo;
 
 use public_ip::{dns, http, BoxToResolver, ToResolver};
 
-use crate::RedirectIP;
+use crate::RedirectIp;
 
 pub async fn get_info<S: AsRef<str>>(
     port: u16,
     subnet_mask: IpAddr,
     name: S,
-    redirect_instructions: RedirectIP,
+    redirect_instructions: RedirectIp,
 ) -> Result<StorageNodeInfo> {
     match redirect_instructions {
-        RedirectIP::Automatic => {
+        RedirectIp::Automatic => {
             let resolver = vec![
                 BoxToResolver::new(dns::OPENDNS_RESOLVER),
                 BoxToResolver::new(http::HTTP_IPIFY_ORG_RESOLVER),
@@ -41,7 +41,7 @@ pub async fn get_info<S: AsRef<str>>(
                 port,
             })
         }
-        RedirectIP::Static(static_redirect) => Ok(StorageNodeInfo {
+        RedirectIp::Static(static_redirect) => Ok(StorageNodeInfo {
             id: name.as_ref().to_string(),
             redirect_info: interface::RedirectInfo::Static {
                 static_address: static_redirect,

--- a/bin/menmosd/src/menmosd/config.rs
+++ b/bin/menmosd/src/menmosd/config.rs
@@ -58,6 +58,7 @@ pub struct HttpParameters {
 
 #[derive(Clone, Deserialize, Serialize)]
 #[serde(tag = "type")]
+#[serde(rename_all = "lowercase")]
 pub enum ServerSetting {
     Http(HttpParameters),
     Https(HttpsParameters),

--- a/bin/menmosd/src/menmosd/config.rs
+++ b/bin/menmosd/src/menmosd/config.rs
@@ -16,7 +16,7 @@ const DEFAULT_HTTP_PORT: i64 = 80;
 const DEFAULT_HTTPS_PORT: i64 = 443;
 
 #[derive(Clone, Deserialize, Serialize)]
-pub struct DNSParameters {
+pub struct DnsParameters {
     pub host_name: String, // The domain name of *this* node (for the example below, this would be "dir.storage.com").
     pub root_domain: String, // The domain for which to generate the wildcard cert (e.g. if you want a cert for "*.storage.com" and a directory node on "dir.storage.com", put "storage.com" here)
     pub public_ip: IpAddr,
@@ -26,41 +26,41 @@ pub struct DNSParameters {
 }
 
 #[derive(Clone, Deserialize, Serialize)]
-pub struct HTTPSParameters {
+pub struct HttpsParameters {
     pub http_port: u16,
     pub https_port: u16,
     pub certificate_storage_path: PathBuf,
     pub letsencrypt_email: String,
 
-    #[serde(default = "LetsEncryptURL::default")]
-    pub letsencrypt_url: LetsEncryptURL,
+    #[serde(default = "LetsEncryptUrl::default")]
+    pub letsencrypt_url: LetsEncryptUrl,
 
-    pub dns: DNSParameters,
+    pub dns: DnsParameters,
 }
 
 #[derive(Clone, Deserialize, Serialize, PartialEq)]
 #[serde(rename_all = "lowercase")]
-pub enum LetsEncryptURL {
+pub enum LetsEncryptUrl {
     Production,
     Staging,
 }
 
-impl Default for LetsEncryptURL {
+impl Default for LetsEncryptUrl {
     fn default() -> Self {
-        LetsEncryptURL::Production
+        LetsEncryptUrl::Production
     }
 }
 
 #[derive(Clone, Deserialize, Serialize)]
-pub struct HTTPParameters {
+pub struct HttpParameters {
     pub port: u16,
 }
 
 #[derive(Clone, Deserialize, Serialize)]
 #[serde(tag = "type")]
 pub enum ServerSetting {
-    HTTP(HTTPParameters),
-    HTTPS(HTTPSParameters),
+    Http(HttpParameters),
+    Https(HttpsParameters),
 }
 
 #[derive(Clone, Deserialize, Serialize)]

--- a/bin/menmosd/src/menmosd/network/redirect.rs
+++ b/bin/menmosd/src/menmosd/network/redirect.rs
@@ -43,7 +43,7 @@ pub fn get_storage_node_address<S: AsRef<str>>(
     };
 
     let fmt_url = match &cfg.server {
-        ServerSetting::HTTP(_http_setting) => {
+        ServerSetting::Http(_http_setting) => {
             format!(
                 "http://{}:{}/{}",
                 address.to_string(),
@@ -51,7 +51,7 @@ pub fn get_storage_node_address<S: AsRef<str>>(
                 path.as_ref()
             )
         }
-        ServerSetting::HTTPS(https_setting) => {
+        ServerSetting::Https(https_setting) => {
             format!(
                 "https://{}.{}:{}/{}",
                 address.to_string().replace('.', "-"),

--- a/bin/menmosd/src/menmosd/node/test/mock.rs
+++ b/bin/menmosd/src/menmosd/node/test/mock.rs
@@ -21,14 +21,14 @@ fn tag_to_kv(tag: &str) -> Result<(&str, &str)> {
 }
 
 #[derive(Default)]
-pub struct MockDocIDMap {
+pub struct MockDocIdMap {
     forward_map: Mutex<HashMap<String, u32>>,
     backward_map: Mutex<HashMap<u32, String>>,
     recycled_ids: Mutex<Vec<u32>>,
     next_id: AtomicU32,
 }
 
-impl DocIDMapper for MockDocIDMap {
+impl DocIdMapper for MockDocIdMap {
     fn get_nb_of_docs(&self) -> u32 {
         self.next_id.load(Ordering::SeqCst)
     }
@@ -387,7 +387,7 @@ impl UserMapper for MockUserMap {
 
 #[derive(Default)]
 pub struct MockIndex {
-    documents: Arc<MockDocIDMap>,
+    documents: Arc<MockDocIdMap>,
     meta: Arc<MockMetaMap>,
     routing: Arc<MockRoutingMap>,
     storage: Arc<MockStorageMap>,
@@ -403,7 +403,7 @@ impl Flush for MockIndex {
 
 impl IndexProvider for MockIndex {
     type MetadataProvider = MockMetaMap;
-    type DocumentProvider = MockDocIDMap;
+    type DocumentProvider = MockDocIdMap;
     type RoutingProvider = MockRoutingMap;
     type StorageProvider = MockStorageMap;
     type UserProvider = MockUserMap;

--- a/bin/menmosd/src/menmosd/server/server_impl.rs
+++ b/bin/menmosd/src/menmosd/server/server_impl.rs
@@ -33,7 +33,7 @@ impl Server {
 
         let node_cloned = node.clone();
         let join_handle = match cfg.server {
-            ServerSetting::HTTPS(https_cfg) => spawn(async move {
+            ServerSetting::Https(https_cfg) => spawn(async move {
                 match use_tls(node_cloned, config, https_cfg, stop_rx).await {
                     Ok(_) => {}
                     Err(e) => {
@@ -41,7 +41,7 @@ impl Server {
                     }
                 }
             }),
-            ServerSetting::HTTP(http_cfg) => {
+            ServerSetting::Http(http_cfg) => {
                 log::info!("starting http layer");
                 let server_context = Context {
                     node: node.clone(),

--- a/bin/menmosd/src/menmosd/server/ssl.rs
+++ b/bin/menmosd/src/menmosd/server/ssl.rs
@@ -23,7 +23,7 @@ use warp::Filter;
 use x509_parser::pem::Pem;
 
 use crate::{
-    config::{HTTPSParameters, LetsEncryptURL},
+    config::{HttpsParameters, LetsEncryptUrl},
     server::{filters, Context},
     Config,
 };
@@ -75,7 +75,7 @@ async fn wait_for_server_stop(http_handle: JoinHandle<()>, https_handle: JoinHan
 pub async fn use_tls(
     n: Arc<Box<dyn DirectoryNode + Send + Sync>>,
     node_cfg: Arc<Config>,
-    cfg: HTTPSParameters,
+    cfg: HttpsParameters,
     mut stop_rx: mpsc::Receiver<()>,
 ) -> Result<()> {
     let dns_server = DnsServer::start(DnsConfig {
@@ -98,7 +98,7 @@ pub async fn use_tls(
         .join(&cfg.dns.root_domain)
         .with_extension("key");
 
-    let url = if cfg.letsencrypt_url == LetsEncryptURL::Production {
+    let url = if cfg.letsencrypt_url == LetsEncryptUrl::Production {
         acme_lib::DirectoryUrl::LetsEncrypt
     } else {
         acme_lib::DirectoryUrl::LetsEncryptStaging

--- a/crates/lfan/src/cache/mod.rs
+++ b/crates/lfan/src/cache/mod.rs
@@ -13,4 +13,4 @@ pub use concurrent_cache::ConcurrentCache;
 
 pub use modular_cache::ModularCache;
 pub use policy::{EvictionPolicy, InsertionPolicy};
-pub use ttl_cache::TTLCache;
+pub use ttl_cache::TtlCache;

--- a/crates/lfan/src/cache/ttl_cache.rs
+++ b/crates/lfan/src/cache/ttl_cache.rs
@@ -29,7 +29,7 @@ impl<V> From<V> for CacheItem<V> {
 }
 
 #[derive(Default)]
-pub struct TTLCache<K, V, IP, EP>
+pub struct TtlCache<K, V, IP, EP>
 where
     K: Hash + Eq,
     IP: Default + InsertionPolicy<K>,
@@ -45,7 +45,7 @@ where
     maximum_size: usize,
 }
 
-impl<K, V, IP, EP> TTLCache<K, V, IP, EP>
+impl<K, V, IP, EP> TtlCache<K, V, IP, EP>
 where
     K: Hash + Eq + std::fmt::Debug,
     IP: Default + InsertionPolicy<K>,
@@ -62,7 +62,7 @@ where
     }
 }
 
-impl<K, V, IP, EP> Cache for TTLCache<K, V, IP, EP>
+impl<K, V, IP, EP> Cache for TtlCache<K, V, IP, EP>
 where
     K: Hash + Eq + std::fmt::Debug,
     IP: Default + InsertionPolicy<K>,

--- a/crates/lfan/src/lib.rs
+++ b/crates/lfan/src/lib.rs
@@ -1,41 +1,41 @@
 mod cache;
 mod policy;
 
-pub use cache::{EvictionPolicy, InsertionPolicy, ModularCache, TTLCache};
+pub use cache::{EvictionPolicy, InsertionPolicy, ModularCache, TtlCache};
 
 pub mod preconfig {
-    use super::policy::eviction::LRUEvictionPolicy;
+    use super::policy::eviction::LruEvictionPolicy;
     use super::policy::insertion::AlwaysInsertPolicy;
     use super::ModularCache;
 
-    pub type LRUCache<K, V> = ModularCache<K, V, AlwaysInsertPolicy, LRUEvictionPolicy<K>>;
-    pub type TTLLRUCache<K, V> = super::TTLCache<K, V, AlwaysInsertPolicy, LRUEvictionPolicy<K>>;
+    pub type LruCache<K, V> = ModularCache<K, V, AlwaysInsertPolicy, LruEvictionPolicy<K>>;
+    pub type TtlLruCache<K, V> = super::TtlCache<K, V, AlwaysInsertPolicy, LruEvictionPolicy<K>>;
 
     #[cfg(feature = "async")]
     pub mod concurrent {
-        use super::LRUCache as SingleThreadLRUCache;
-        use super::TTLLRUCache as SingleThreadTTLCache;
+        use super::LruCache as SingleThreadLruCache;
+        use super::TtlLruCache as SingleThreadTtlCache;
         use crate::cache::ConcurrentCache;
         use std::{hash::Hash, time::Duration};
 
-        pub type LRUCache<K, V> = ConcurrentCache<SingleThreadLRUCache<K, V>>;
+        pub type LruCache<K, V> = ConcurrentCache<SingleThreadLruCache<K, V>>;
 
-        pub fn new_lru_cache<K, V>(maximum_size: usize) -> LRUCache<K, V>
+        pub fn new_lru_cache<K, V>(maximum_size: usize) -> LruCache<K, V>
         where
             K: Hash + Eq + Clone + std::fmt::Debug,
             V: Clone,
         {
-            LRUCache::new(SingleThreadLRUCache::new(maximum_size))
+            LruCache::new(SingleThreadLruCache::new(maximum_size))
         }
 
-        pub type TTLLRUCache<K, V> = ConcurrentCache<SingleThreadTTLCache<K, V>>;
+        pub type TtlLruCache<K, V> = ConcurrentCache<SingleThreadTtlCache<K, V>>;
 
-        pub fn new_ttl_cache<K, V>(maximum_size: usize, ttl: Duration) -> TTLLRUCache<K, V>
+        pub fn new_ttl_cache<K, V>(maximum_size: usize, ttl: Duration) -> TtlLruCache<K, V>
         where
             K: Hash + Eq + Clone + std::fmt::Debug,
             V: Clone,
         {
-            TTLLRUCache::new(SingleThreadTTLCache::new(maximum_size, ttl))
+            TtlLruCache::new(SingleThreadTtlCache::new(maximum_size, ttl))
         }
     }
 }

--- a/crates/lfan/src/policy/evict_lru.rs
+++ b/crates/lfan/src/policy/evict_lru.rs
@@ -7,25 +7,25 @@ use crate::cache::EvictionPolicy;
 
 struct Nothing;
 
-pub struct LRUEvictionPolicy<K>
+pub struct LruEvictionPolicy<K>
 where
     K: Eq + Hash + Clone,
 {
     data: LinkedHashMap<K, Nothing>,
 }
 
-impl<K> Default for LRUEvictionPolicy<K>
+impl<K> Default for LruEvictionPolicy<K>
 where
     K: Eq + Hash + Clone,
 {
     fn default() -> Self {
-        LRUEvictionPolicy {
+        LruEvictionPolicy {
             data: LinkedHashMap::new(),
         }
     }
 }
 
-impl<K> EvictionPolicy<K> for LRUEvictionPolicy<K>
+impl<K> EvictionPolicy<K> for LruEvictionPolicy<K>
 where
     K: Eq + Hash + Clone,
 {

--- a/crates/lfan/src/policy/mod.rs
+++ b/crates/lfan/src/policy/mod.rs
@@ -6,5 +6,5 @@ pub mod insertion {
 }
 
 pub mod eviction {
-    pub use super::evict_lru::LRUEvictionPolicy;
+    pub use super::evict_lru::LruEvictionPolicy;
 }

--- a/crates/menmos-antidns/src/extract.rs
+++ b/crates/menmos-antidns/src/extract.rs
@@ -10,7 +10,7 @@ use snafu::{ensure, Snafu};
 
 #[derive(Debug, Snafu)]
 pub enum Error {
-    NameWithoutIP,
+    NameWithoutIp,
     ParseError { message: String },
     IncompleteParse,
 }
@@ -28,7 +28,7 @@ fn ip_address(i: &str) -> IResult<&str, Ipv4Addr> {
 
 pub fn ip_address_from_url<S: AsRef<str>>(url: S) -> Result<Ipv4Addr, Error> {
     let splitted: Vec<_> = url.as_ref().split('.').collect();
-    ensure!(splitted.len() >= 2, NameWithoutIP);
+    ensure!(splitted.len() >= 2, NameWithoutIp);
 
     let ip_segment = *splitted.first().unwrap();
     let (rest, ip) = ip_address(ip_segment).map_err(|e| Error::ParseError {

--- a/crates/menmos-antidns/src/header.rs
+++ b/crates/menmos-antidns/src/header.rs
@@ -42,7 +42,7 @@ impl DnsHeader {
             opcode: 0,
             response: false,
 
-            rescode: ResultCode::NOERROR,
+            rescode: ResultCode::NoError,
             checking_disabled: false,
             authed_data: false,
             z: false,

--- a/crates/menmos-antidns/src/query_type.rs
+++ b/crates/menmos-antidns/src/query_type.rs
@@ -1,13 +1,21 @@
 #[derive(PartialEq, Eq, Debug, Clone, Hash, Copy)]
 pub enum QueryType {
+    #[allow(clippy::upper_case_acronyms)]
     UNKNOWN(u16),
-    A,     // 1
-    NS,    // 2
+    #[allow(clippy::upper_case_acronyms)]
+    A, // 1
+    #[allow(clippy::upper_case_acronyms)]
+    NS, // 2
+    #[allow(clippy::upper_case_acronyms)]
     CNAME, // 5
-    MX,    // 15
-    TXT,   // 16
-    AAAA,  // 28
-    CAA,   // 257
+    #[allow(clippy::upper_case_acronyms)]
+    MX, // 15
+    #[allow(clippy::upper_case_acronyms)]
+    TXT, // 16
+    #[allow(clippy::upper_case_acronyms)]
+    AAAA, // 28
+    #[allow(clippy::upper_case_acronyms)]
+    CAA, // 257
 }
 
 impl QueryType {

--- a/crates/menmos-antidns/src/record.rs
+++ b/crates/menmos-antidns/src/record.rs
@@ -14,34 +14,41 @@ type Result<T> = std::result::Result<T, RecordError>;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 #[allow(dead_code)]
+#[allow(clippy::upper_case_acronyms)] // We allow for this because DNS queries are always written uppercase.
 pub enum DnsRecord {
+    #[allow(clippy::upper_case_acronyms)]
     UNKNOWN {
         domain: String,
         qtype: u16,
         data_len: u16,
         ttl: u32,
     }, // 0
+    #[allow(clippy::upper_case_acronyms)]
     A {
         domain: String,
         addr: Ipv4Addr,
         ttl: u32,
     }, // 1
+    #[allow(clippy::upper_case_acronyms)]
     NS {
         domain: String,
         host: String,
         ttl: u32,
     }, // 2
+    #[allow(clippy::upper_case_acronyms)]
     CNAME {
         domain: String,
         host: String,
         ttl: u32,
     }, // 5
+    #[allow(clippy::upper_case_acronyms)]
     MX {
         domain: String,
         priority: u16,
         host: String,
         ttl: u32,
     }, // 15
+    #[allow(clippy::upper_case_acronyms)]
     TXT {
         domain_bytes: Vec<u8>, // usually 2 bytes (jump).
         // Qtype => 2 bytes
@@ -50,11 +57,13 @@ pub enum DnsRecord {
         data_len: u16, // 2 bytes
         text: Vec<Vec<u8>>,
     }, // 16
+    #[allow(clippy::upper_case_acronyms)]
     AAAA {
         domain: String,
         addr: Ipv6Addr,
         ttl: u32,
     }, // 28
+    #[allow(clippy::upper_case_acronyms)]
     CAA {},
 }
 

--- a/crates/menmos-antidns/src/resolver.rs
+++ b/crates/menmos-antidns/src/resolver.rs
@@ -7,7 +7,7 @@ use crate::{Config, DnsPacket, DnsRecord, QueryType};
 
 #[derive(Debug, Snafu)]
 pub enum ResolveError {
-    UnexpectedIPV6,
+    UnexpectedIpv6,
 }
 
 type Result<T> = std::result::Result<T, ResolveError>;
@@ -31,7 +31,7 @@ fn in_house_resolution(qname: &str, ip: IpAddr) -> Result<DnsPacket> {
 
             Ok(pkt)
         }
-        IpAddr::V6(_) => Err(ResolveError::UnexpectedIPV6),
+        IpAddr::V6(_) => Err(ResolveError::UnexpectedIpv6),
     }
 }
 

--- a/crates/menmos-antidns/src/result_code.rs
+++ b/crates/menmos-antidns/src/result_code.rs
@@ -1,22 +1,22 @@
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum ResultCode {
-    NOERROR = 0,
-    FORMERR = 1,
-    SERVFAIL = 2,
-    NXDOMAIN = 3,
-    NOTIMP = 4,
-    REFUSED = 5,
+    NoError = 0,
+    FormErr = 1,
+    ServFail = 2,
+    NxDomain = 3,
+    NoTimp = 4,
+    Refused = 5,
 }
 
 impl ResultCode {
     pub fn from_num(num: u8) -> ResultCode {
         match num {
-            1 => ResultCode::FORMERR,
-            2 => ResultCode::SERVFAIL,
-            3 => ResultCode::NXDOMAIN,
-            4 => ResultCode::NOTIMP,
-            5 => ResultCode::REFUSED,
-            _ => ResultCode::NOERROR,
+            1 => ResultCode::FormErr,
+            2 => ResultCode::ServFail,
+            3 => ResultCode::NxDomain,
+            4 => ResultCode::NoTimp,
+            5 => ResultCode::Refused,
+            _ => ResultCode::NoError,
         }
     }
 }

--- a/crates/menmos-antidns/src/server.rs
+++ b/crates/menmos-antidns/src/server.rs
@@ -26,8 +26,6 @@ pub enum ServerError {
 
     ResolutionError { source: ResolveError },
 
-    CantFindPublicIP,
-
     JoinError,
     PoisonedMutex,
 }
@@ -141,7 +139,7 @@ impl Server {
                     }
                     Err(e) => {
                         log::error!("servfail: {}", e);
-                        packet.header.rescode = ResultCode::SERVFAIL;
+                        packet.header.rescode = ResultCode::ServFail;
                     }
                 }
             }
@@ -151,7 +149,7 @@ impl Server {
         // to indicate that the sender made something wrong.
         else {
             log::warn!("FORMERR");
-            packet.header.rescode = ResultCode::FORMERR;
+            packet.header.rescode = ResultCode::FormErr;
         }
 
         // The only thing remaining is to encode our response and send it off!

--- a/crates/menmos-betterstreams/src/fs.rs
+++ b/crates/menmos-betterstreams/src/fs.rs
@@ -15,7 +15,7 @@ use tokio::fs;
 use tokio::io::{AsyncSeekExt, AsyncWriteExt};
 use tokio_util::io::poll_read_buf;
 
-use crate::{ChunkedStreamInfo, UnpinDynIOStream};
+use crate::{ChunkedStreamInfo, UnpinDynIoStream};
 
 const DEFAULT_READ_BUF_SIZE: usize = 8_192;
 
@@ -23,15 +23,15 @@ const DEFAULT_READ_BUF_SIZE: usize = 8_192;
 ///
 /// # Examples
 /// ```no_run
-/// use betterstreams::{fs, UnpinDynIOStream};
+/// use betterstreams::{fs, UnpinDynIoStream};
 /// use tokio::runtime::Runtime;
 ///
 /// Runtime::new().unwrap().block_on(async {
-///     let mystream: UnpinDynIOStream = { unimplemented!(); };
+///     let mystream: UnpinDynIoStream = { unimplemented!(); };
 ///     fs::write_all("/home/user/myfile.txt", mystream).await.unwrap();
 /// });
 /// ```
-pub async fn write_all<P: AsRef<Path>>(path: P, stream: UnpinDynIOStream) -> Result<()> {
+pub async fn write_all<P: AsRef<Path>>(path: P, stream: UnpinDynIoStream) -> Result<()> {
     let mut stream_pin = Box::pin(stream);
 
     let mut f = fs::File::create(path.as_ref()).await?;

--- a/crates/menmos-betterstreams/src/lib.rs
+++ b/crates/menmos-betterstreams/src/lib.rs
@@ -10,18 +10,18 @@ pub mod util;
 /// A boxed stream of [`Bytes`] that can be unpinned.
 ///
 /// [`Bytes`]: bytes::Bytes
-pub type UnpinDynIOStream =
+pub type UnpinDynIoStream =
     Box<dyn Stream<Item = Result<Bytes, io::Error>> + Send + Sync + Unpin + 'static>;
 
 /// A boxed stream of [`Bytes`].
 ///
 /// [`Bytes`]: bytes::Bytes
-pub type DynIOStream = Box<dyn Stream<Item = Result<Bytes, io::Error>> + Send + Sync + 'static>;
+pub type DynIoStream = Box<dyn Stream<Item = Result<Bytes, io::Error>> + Send + Sync + 'static>;
 
 /// A stream that can be part of a larger file.
 pub struct ChunkedStreamInfo {
     /// The stream data.
-    pub stream: DynIOStream,
+    pub stream: DynIoStream,
 
     /// The size of the current stream chunk, in bytes.
     pub chunk_size: u64,

--- a/crates/menmos-indexer/src/documents.rs
+++ b/crates/menmos-indexer/src/documents.rs
@@ -8,13 +8,13 @@ use bitvec::prelude::*;
 
 use byteorder::{BigEndian, ReadBytesExt};
 
-use crate::iface::{DocIDMapper, Flush};
+use crate::iface::{DocIdMapper, Flush};
 
 const DOC_MAP: &str = "document";
 const DOC_REV_MAP: &str = "document-rev";
 const RECYCLING_STORE: &str = "id-recycle";
 
-pub struct DocumentIDStore {
+pub struct DocumentIdStore {
     doc_map: sled::Tree,         // DocumentID => IDX
     doc_reverse_map: sled::Tree, // IDX => DocumentID
     recycling_store: sled::Tree,
@@ -22,7 +22,7 @@ pub struct DocumentIDStore {
     next_id: AtomicU32,
 }
 
-impl DocumentIDStore {
+impl DocumentIdStore {
     pub fn new(db: &sled::Db) -> Result<Self> {
         let doc_map = db.open_tree(DOC_MAP)?;
         let doc_reverse_map = db.open_tree(DOC_REV_MAP)?;
@@ -43,7 +43,7 @@ impl DocumentIDStore {
 }
 
 #[async_trait]
-impl Flush for DocumentIDStore {
+impl Flush for DocumentIdStore {
     async fn flush(&self) -> Result<()> {
         log::debug!("beginning flush");
         self.doc_map.flush_async().await?;
@@ -53,7 +53,7 @@ impl Flush for DocumentIDStore {
     }
 }
 
-impl DocIDMapper for DocumentIDStore {
+impl DocIdMapper for DocumentIdStore {
     fn get_nb_of_docs(&self) -> u32 {
         self.next_id.load(Ordering::SeqCst)
     }

--- a/crates/menmos-indexer/src/iface.rs
+++ b/crates/menmos-indexer/src/iface.rs
@@ -14,7 +14,7 @@ pub trait Flush {
     async fn flush(&self) -> Result<()>;
 }
 
-pub trait DocIDMapper {
+pub trait DocIdMapper {
     fn get_nb_of_docs(&self) -> u32;
     fn insert(&self, doc_id: &str) -> Result<u32>;
     fn get(&self, doc_id: &str) -> Result<Option<u32>>;
@@ -69,7 +69,7 @@ pub trait UserMapper {
 }
 
 pub trait IndexProvider {
-    type DocumentProvider: DocIDMapper + Send + Sync;
+    type DocumentProvider: DocIdMapper + Send + Sync;
     type MetadataProvider: MetadataMapper + Send + Sync;
     type RoutingProvider: RoutingMapper + Send + Sync;
     type StorageProvider: StorageNodeMapper + Send + Sync;

--- a/crates/menmos-indexer/src/root.rs
+++ b/crates/menmos-indexer/src/root.rs
@@ -6,7 +6,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 
 use crate::{
-    documents::DocumentIDStore, meta::MetadataStore, routing::RoutingStore,
+    documents::DocumentIdStore, meta::MetadataStore, routing::RoutingStore,
     storage::StorageDispatch,
 };
 use crate::{
@@ -17,7 +17,7 @@ use crate::{
 pub struct Index {
     db: sled::Db,
 
-    documents: Arc<DocumentIDStore>,
+    documents: Arc<DocumentIdStore>,
     meta: Arc<MetadataStore>,
     routing: Arc<RoutingStore>,
     storage: Arc<StorageDispatch>,
@@ -27,7 +27,7 @@ pub struct Index {
 impl Index {
     pub fn new<P: AsRef<Path>>(path: P) -> Result<Self> {
         let db = sled::open(path.as_ref())?;
-        let documents = Arc::from(DocumentIDStore::new(&db)?);
+        let documents = Arc::from(DocumentIdStore::new(&db)?);
         let meta = Arc::from(MetadataStore::new(&db)?);
         let routing = Arc::from(RoutingStore::new(&db)?);
         let storage = Arc::from(StorageDispatch::new(&db)?);
@@ -59,7 +59,7 @@ impl Flush for Index {
 }
 
 impl IndexProvider for Index {
-    type DocumentProvider = DocumentIDStore;
+    type DocumentProvider = DocumentIdStore;
     type MetadataProvider = MetadataStore;
     type RoutingProvider = RoutingStore;
     type StorageProvider = StorageDispatch;

--- a/crates/menmos-indexer/src/test/document.rs
+++ b/crates/menmos-indexer/src/test/document.rs
@@ -4,14 +4,14 @@ use bitvec::prelude::*;
 
 use tempfile::TempDir;
 
-use crate::{documents::DocumentIDStore, iface::DocIDMapper};
+use crate::{documents::DocumentIdStore, iface::DocIdMapper};
 
 #[test]
 fn nb_of_docs_initially_zero() {
     let d = TempDir::new().unwrap();
     let db = sled::open(d.path()).unwrap();
 
-    let doc_map = DocumentIDStore::new(&db).unwrap();
+    let doc_map = DocumentIdStore::new(&db).unwrap();
 
     assert_eq!(doc_map.get_nb_of_docs(), 0);
 }
@@ -21,7 +21,7 @@ fn get_returns_same_doc_id() -> Result<()> {
     let d = TempDir::new()?;
     let db = sled::open(d.path())?;
 
-    let doc_map = DocumentIDStore::new(&db)?;
+    let doc_map = DocumentIdStore::new(&db)?;
     let id = doc_map.insert("abc")?;
     assert_eq!(doc_map.get("abc")?.unwrap(), id);
 
@@ -33,7 +33,7 @@ fn ids_increase_incrementally() {
     let d = TempDir::new().unwrap();
     let db = sled::open(d.path()).unwrap();
 
-    let doc_map = DocumentIDStore::new(&db).unwrap();
+    let doc_map = DocumentIdStore::new(&db).unwrap();
 
     for i in 0..100 {
         assert_eq!(doc_map.insert(&format!("{}", i)).unwrap(), i);
@@ -45,7 +45,7 @@ fn same_key_gets_same_id() {
     let d = TempDir::new().unwrap();
     let db = sled::open(d.path()).unwrap();
 
-    let doc_map = DocumentIDStore::new(&db).unwrap();
+    let doc_map = DocumentIdStore::new(&db).unwrap();
 
     for _i in 0..100 {
         assert_eq!(doc_map.insert("yeet").unwrap(), 0);
@@ -57,7 +57,7 @@ fn ids_lookup_are_reversible() {
     let d = TempDir::new().unwrap();
     let db = sled::open(d.path()).unwrap();
 
-    let doc_map = DocumentIDStore::new(&db).unwrap();
+    let doc_map = DocumentIdStore::new(&db).unwrap();
 
     for i in 0..100 {
         let key = format!("{}", i);
@@ -73,7 +73,7 @@ fn reloading_map_keeps_keys_and_indices() {
     {
         let db = sled::open(d.path()).unwrap();
 
-        let doc_map = DocumentIDStore::new(&db).unwrap();
+        let doc_map = DocumentIdStore::new(&db).unwrap();
 
         for i in 0..100 {
             doc_map.insert(&format!("{}", i)).unwrap();
@@ -84,7 +84,7 @@ fn reloading_map_keeps_keys_and_indices() {
     {
         let db = sled::open(d.path()).unwrap();
 
-        let doc_map = DocumentIDStore::new(&db).unwrap();
+        let doc_map = DocumentIdStore::new(&db).unwrap();
 
         for i in 0..100 {
             assert_eq!(doc_map.lookup(i).unwrap().unwrap(), format!("{}", i));
@@ -100,7 +100,7 @@ fn lookup_of_missing_key_doesnt_fail() {
     let d = TempDir::new().unwrap();
     let db = sled::open(d.path()).unwrap();
 
-    let doc_map = DocumentIDStore::new(&db).unwrap();
+    let doc_map = DocumentIdStore::new(&db).unwrap();
 
     assert_eq!(doc_map.lookup(42).unwrap(), None);
 }
@@ -112,7 +112,7 @@ fn no_data_loss_after_1024_inserts() -> Result<()> {
     let db = sled::open(d.path()).unwrap();
 
     {
-        let doc_map = DocumentIDStore::new(&db).unwrap();
+        let doc_map = DocumentIdStore::new(&db).unwrap();
         for i in 0..2000 {
             let id = doc_map.insert(&format!("{}", i))?;
             assert_eq!(id, i);
@@ -120,7 +120,7 @@ fn no_data_loss_after_1024_inserts() -> Result<()> {
     }
 
     {
-        let doc_map = DocumentIDStore::new(&db).unwrap();
+        let doc_map = DocumentIdStore::new(&db).unwrap();
         let id = doc_map.insert("asdf")?;
         assert_eq!(id, 2000);
     }
@@ -133,7 +133,7 @@ fn delete_document() -> Result<()> {
     let d = TempDir::new().unwrap();
     let db = sled::open(d.path()).unwrap();
 
-    let doc_map = DocumentIDStore::new(&db).unwrap();
+    let doc_map = DocumentIdStore::new(&db).unwrap();
     let id = doc_map.insert("hello")?;
 
     doc_map.delete("hello")?;
@@ -148,7 +148,7 @@ fn get_all_documents_mask() -> Result<()> {
     let d = TempDir::new().unwrap();
     let db = sled::open(d.path()).unwrap();
 
-    let doc_map = DocumentIDStore::new(&db).unwrap();
+    let doc_map = DocumentIdStore::new(&db).unwrap();
     doc_map.insert("hello")?;
     doc_map.insert("there")?;
     doc_map.insert("world")?;
@@ -167,7 +167,7 @@ fn deleted_ids_are_recycled_properly() -> Result<()> {
     let d = TempDir::new().unwrap();
     let db = sled::open(d.path()).unwrap();
 
-    let doc_map = DocumentIDStore::new(&db).unwrap();
+    let doc_map = DocumentIdStore::new(&db).unwrap();
     doc_map.insert("hello")?; // id 0
     doc_map.insert("there")?; // id 1
     doc_map.insert("world")?; // id 2

--- a/crates/menmos-repository/src/s3/file_cache.rs
+++ b/crates/menmos-repository/src/s3/file_cache.rs
@@ -2,14 +2,14 @@ use std::path::PathBuf;
 
 use anyhow::{anyhow, Result};
 use futures::StreamExt;
-use lfan::preconfig::concurrent::{new_lru_cache, LRUCache};
+use lfan::preconfig::concurrent::{new_lru_cache, LruCache};
 use rusoto_s3::{GetObjectRequest, S3Client, S3};
 use tokio::{fs, io::AsyncWriteExt};
 
 pub struct FileCache {
     bucket: String,
     client: S3Client,
-    file_path_cache: LRUCache<String, PathBuf>,
+    file_path_cache: LruCache<String, PathBuf>,
     root_path: PathBuf,
 }
 

--- a/crates/menmos-testing/src/fixtures/data/menmosd_http.toml
+++ b/crates/menmos-testing/src/fixtures/data/menmosd_http.toml
@@ -1,5 +1,5 @@
 [server]
-type = "HTTP"
+type = "Http"
 port = 3030
 
 [node]

--- a/crates/menmos-testing/src/fixtures/data/menmosd_http.toml
+++ b/crates/menmos-testing/src/fixtures/data/menmosd_http.toml
@@ -1,5 +1,5 @@
 [server]
-type = "Http"
+type = "http"
 port = 3030
 
 [node]

--- a/crates/menmos-testing/src/fixtures/mod.rs
+++ b/crates/menmos-testing/src/fixtures/mod.rs
@@ -8,7 +8,7 @@ use log::LevelFilter;
 use log4rs::append::console::ConsoleAppender;
 use log4rs::config::{Appender, Config as LogConfig, Root};
 use menmos_client::{Client, Meta};
-use menmosd::config::{HTTPParameters, ServerSetting};
+use menmosd::config::{HttpParameters, ServerSetting};
 use menmosd::{Config, Server};
 use tempfile::{NamedTempFile, TempDir};
 
@@ -51,7 +51,7 @@ impl Menmos {
         cfg.node.db_path = db_path;
 
         let port = portpicker::pick_unused_port().unwrap();
-        cfg.server = ServerSetting::HTTP(HTTPParameters { port });
+        cfg.server = ServerSetting::Http(HttpParameters { port });
 
         let node = menmosd::make_node(&cfg)?;
 


### PR DESCRIPTION
The upgrade to rust 1.50 added new lints to clippy that we needed to fix.

Note: This brings a config breaking change. `server.type` in the directory config now needs to be lowercased. The documentation has been updated accordingly.