### PR TITLE
Fix missing chrono feature

### DIFF
--- a/crates/menmos-interface/Cargo.toml
+++ b/crates/menmos-interface/Cargo.toml
@@ -17,7 +17,7 @@ anyhow = "1"
 base64 = "0.13"
 bytes = "1"
 async-trait = "0.1.42"
-chrono = "0.4"
+chrono = {version = "0.4", features = ["serde"]}
 futures = "0.3"
 headers = "=0.3.3"
 rapidquery = {version = "0.0.5", features=["bitvec_span"]}


### PR DESCRIPTION
This is a quick one. Seems like chrono was missing a feature flag on the `menmos-interface` crate. This _should_ have caused compilation issues, but for some reason it compiled fine everywhere except on my laptop.