### PR TITLE
[MEN-24] - Directory routes blobs according to routing key if available

### DIFF
--- a/bin/menmosd/src/menmosd/node/node_impl.rs
+++ b/bin/menmosd/src/menmosd/node/node_impl.rs
@@ -89,8 +89,9 @@ where
         &self,
         blob_id: &str,
         meta: BlobMetaRequest,
+        username: &str,
     ) -> Result<StorageNodeInfo> {
-        self.node_router.route_blob(blob_id, &meta).await
+        self.node_router.route_blob(blob_id, &meta, username).await
     }
 
     async fn get_blob_meta(&self, blob_id: &str, username: &str) -> Result<Option<BlobInfo>> {

--- a/bin/menmosd/src/menmosd/node/routing/router.rs
+++ b/bin/menmosd/src/menmosd/node/routing/router.rs
@@ -90,20 +90,15 @@ where
         meta_request: &BlobMetaRequest,
         username: &str,
     ) -> Result<Option<StorageNodeInfo>> {
-        let routed_storage_node_maybe = self
-            .index
-            .get_routing_config(username)?
-            .map(|routing_config| {
+        let routed_storage_node_maybe =
+            if let Some(routing_config) = self.index.get_routing_config(username)? {
                 meta_request
                     .metadata
                     .get(&routing_config.routing_key)
-                    .map(|cfg_value| (routing_config, cfg_value))
-            })
-            .flatten()
-            .map(|(routing_cfg, routing_field_value)| {
-                routing_cfg.routes.get(routing_field_value).cloned()
-            })
-            .flatten();
+                    .and_then(|field_value| routing_config.routes.get(field_value).cloned())
+            } else {
+                None
+            };
 
         if let Some(storage_node_id) = routed_storage_node_maybe {
             self.get_node(&storage_node_id)

--- a/bin/menmosd/src/menmosd/node/test/node.rs
+++ b/bin/menmosd/src/menmosd/node/test/node.rs
@@ -33,7 +33,7 @@ async fn index<S: AsRef<str>, N: DirectoryNode>(
     node: &N,
 ) -> StorageNodeInfo {
     let tgt_storage_node = node
-        .pick_node_for_blob(id.as_ref(), meta_request.clone())
+        .pick_node_for_blob(id.as_ref(), meta_request.clone(), "admin")
         .await
         .unwrap();
 
@@ -54,7 +54,11 @@ async fn index<S: AsRef<str>, N: DirectoryNode>(
 async fn pick_node_for_blob_with_no_storage_nodes() {
     let node = TestDirNode::new(MockIndex::default());
     assert!(node
-        .pick_node_for_blob("bing", BlobMetaRequest::new("somename", Type::File),)
+        .pick_node_for_blob(
+            "bing",
+            BlobMetaRequest::new("somename", Type::File),
+            "admin"
+        )
         .await
         .is_err());
 }

--- a/bin/menmosd/src/menmosd/node/test/node.rs
+++ b/bin/menmosd/src/menmosd/node/test/node.rs
@@ -518,3 +518,108 @@ async fn routing_info_get_set_delete() -> Result<()> {
 
     Ok(())
 }
+
+#[tokio::test]
+async fn add_multi_blob_routing_key() -> Result<()> {
+    let node = TestDirNode::new(MockIndex::default());
+
+    let mut storage_nodes = Vec::with_capacity(3);
+    storage_nodes.push(get_storage_node_info("alpha"));
+    storage_nodes.push(get_storage_node_info("beta"));
+
+    for storage_node in storage_nodes.into_iter() {
+        node.register_storage_node(storage_node).await?;
+    }
+
+    let cfg = RoutingConfig::new("some_field")
+        .with_route("a", "alpha")
+        .with_route("b", "beta");
+
+    node.set_routing_config("admin", &cfg).await?;
+
+    // Test each multiple times so we know it's not round-robin.
+    for _ in 0..10 {
+        let node = node
+            .pick_node_for_blob(
+                "asdf",
+                BlobMetaRequest::file("bing.txt").with_meta("some_field", "a"),
+                "admin",
+            )
+            .await?;
+        assert_eq!(node.id, "alpha");
+    }
+
+    for _ in 0..10 {
+        let node = node
+            .pick_node_for_blob(
+                "asdf",
+                BlobMetaRequest::file("bing.txt").with_meta("some_field", "b"),
+                "admin",
+            )
+            .await?;
+        assert_eq!(node.id, "beta");
+    }
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn add_blob_routing_key_unknown_value() -> Result<()> {
+    let node = TestDirNode::new(MockIndex::default());
+
+    let mut storage_nodes = Vec::with_capacity(3);
+    storage_nodes.push(get_storage_node_info("alpha"));
+    storage_nodes.push(get_storage_node_info("beta"));
+
+    for storage_node in storage_nodes.into_iter() {
+        node.register_storage_node(storage_node).await?;
+    }
+
+    let cfg = RoutingConfig::new("some_field")
+        .with_route("a", "alpha")
+        .with_route("b", "beta");
+
+    node.set_routing_config("admin", &cfg).await?;
+
+    for i in 0..10 {
+        let node = node
+            .pick_node_for_blob(
+                "asdf",
+                BlobMetaRequest::file("bing.txt").with_meta("some_field", "unknown"),
+                "admin",
+            )
+            .await?;
+
+        let expected_node = if i % 2 == 0 { "alpha" } else { "beta" };
+        assert_eq!(node.id, expected_node);
+    }
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn add_blob_routing_key_missing_storage_node() -> Result<()> {
+    let node = TestDirNode::new(MockIndex::default());
+
+    // We only register node alpha.
+    node.register_storage_node(get_storage_node_info("alpha"))
+        .await?;
+
+    // We put alpha *and* beta in the routing config.
+    let cfg = RoutingConfig::new("some_field")
+        .with_route("a", "alpha")
+        .with_route("b", "beta");
+
+    node.set_routing_config("admin", &cfg).await?;
+
+    assert!(node
+        .pick_node_for_blob(
+            "asdf",
+            BlobMetaRequest::file("bing.txt").with_meta("some_field", "b"),
+            "admin"
+        )
+        .await
+        .is_err());
+
+    Ok(())
+}

--- a/bin/menmosd/src/menmosd/server/handlers/blob/put.rs
+++ b/bin/menmosd/src/menmosd/server/handlers/blob/put.rs
@@ -22,7 +22,7 @@ fn parse_metadata(header_value: String) -> Result<BlobMetaRequest> {
 }
 
 pub async fn put(
-    _user: UserIdentity,
+    user: UserIdentity,
     context: Context,
     meta: String,
     addr: Option<SocketAddr>,
@@ -35,7 +35,7 @@ pub async fn put(
     let new_blob_id = uuid::Uuid::new_v4().to_string();
     let targeted_storage_node = context
         .node
-        .pick_node_for_blob(&new_blob_id, meta)
+        .pick_node_for_blob(&new_blob_id, meta, &user.username)
         .await
         .map_err(InternalServerError::from)?;
 

--- a/crates/menmos-interface/src/directory.rs
+++ b/crates/menmos-interface/src/directory.rs
@@ -193,6 +193,7 @@ pub trait DirectoryNode {
         &self,
         blob_id: &str,
         meta: BlobMetaRequest,
+        username: &str,
     ) -> Result<StorageNodeInfo>;
     async fn get_blob_meta(&self, blob_id: &str, user: &str) -> Result<Option<BlobInfo>>;
     async fn index_blob(&self, blob_id: &str, meta: BlobInfo, storage_node_id: &str) -> Result<()>;


### PR DESCRIPTION
Feature is covered by integration tests (at the node level). Sadly no end-to-end tests yet because we don't have a way of knowing externally which node holds which blob (this information isn't exposed in the API)