### PR TITLE
[MEN-48] - Use tokio/tracing instead of log

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,12 +84,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afddf7f520a80dbf76e6f50a35bca42a2331ef227a28b3b6dc5c2e2338d114b1"
 
 [[package]]
-name = "arc-swap"
-version = "0.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dabe5a181f83789739c194cbe5a897dde195078fac08568d09221fd6137a7ba8"
-
-[[package]]
 name = "arrayref"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -585,17 +579,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "derivative"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "digest"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -667,12 +650,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
-name = "dtoa"
-version = "0.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d7ed2934d741c6b37e33e3832298e8850b53fd2d2bea03873375596c7cea4e"
-
-[[package]]
 name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -703,19 +680,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17392a012ea30ef05a610aa97dfb49496e71c9f676b27879922ea5bdf60d9d3f"
-dependencies = [
- "atty",
- "humantime",
- "log",
- "regex",
- "termcolor",
 ]
 
 [[package]]
@@ -1064,12 +1028,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "494b4d60369511e7dea41cf646832512a94e542f68bb9c49e54518e0f468eb47"
 
 [[package]]
-name = "humantime"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
-
-[[package]]
 name = "hyper"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1286,40 +1244,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
  "cfg-if 1.0.0",
- "serde 1.0.123",
-]
-
-[[package]]
-name = "log-mdc"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a94d21414c1f4a51209ad204c1776a3d0765002c76c6abcb602a6f09f1e881c7"
-
-[[package]]
-name = "log4rs"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1572a880d1115ff867396eee7ae2bc924554225e67a0d3c85c745b3e60ca211"
-dependencies = [
- "anyhow",
- "arc-swap",
- "chrono",
- "derivative",
- "fnv",
- "humantime",
- "libc",
- "log",
- "log-mdc",
- "parking_lot",
- "regex",
- "serde 1.0.123",
- "serde-value",
- "serde_json",
- "serde_yaml",
- "thiserror",
- "thread-id",
- "typemap",
- "winapi",
 ]
 
 [[package]]
@@ -1387,12 +1311,12 @@ name = "menmos-antidns"
 version = "0.0.8"
 dependencies = [
  "anyhow",
- "log",
  "nom 6.1.2",
  "portpicker",
  "serde 1.0.123",
  "snafu",
  "tokio",
+ "tracing",
  "trust-dns-resolver",
 ]
 
@@ -1448,7 +1372,6 @@ dependencies = [
  "dirs",
  "futures",
  "hyper",
- "log",
  "menmos-apikit",
  "menmos-interface",
  "menmos-protocol",
@@ -1459,6 +1382,7 @@ dependencies = [
  "snafu",
  "tokio",
  "toml",
+ "tracing",
 ]
 
 [[package]]
@@ -1520,18 +1444,19 @@ dependencies = [
  "amphora",
  "anyhow",
  "futures",
- "log",
- "log4rs",
  "menmos-apikit",
  "menmos-client",
  "menmos-interface",
  "menmos-protocol",
+ "menmos-xecute",
  "menmosd",
  "portpicker",
  "reqwest",
  "serde_json",
  "tempfile",
  "tokio",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -1566,12 +1491,10 @@ dependencies = [
  "clap",
  "config",
  "dirs",
- "env_logger",
  "external-ip",
  "futures",
  "headers",
  "ipnetwork",
- "log",
  "menmos-antidns",
  "menmos-apikit",
  "menmos-client",
@@ -1591,6 +1514,7 @@ dependencies = [
  "sled 0.34.6 (git+https://github.com/spacejam/sled?branch=main)",
  "tempfile",
  "tokio",
+ "tracing",
  "uuid",
  "warp",
  "x509-parser",
@@ -1854,15 +1778,6 @@ dependencies = [
  "libc",
  "pkg-config",
  "vcpkg",
-]
-
-[[package]]
-name = "ordered-float"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "766f840da25490628d8e63e529cd21c014f6600c6b8517add12a6fa6167a6218"
-dependencies = [
- "num-traits 0.2.14",
 ]
 
 [[package]]
@@ -2733,16 +2648,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde-value"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
-dependencies = [
- "ordered-float",
- "serde 1.0.123",
-]
-
-[[package]]
 name = "serde_derive"
 version = "1.0.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2783,18 +2688,6 @@ dependencies = [
  "itoa",
  "ryu",
  "serde 1.0.123",
-]
-
-[[package]]
-name = "serde_yaml"
-version = "0.8.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15654ed4ab61726bf918a39cb8d98a2e2995b002387807fa6ba58fdf7f59bb23"
-dependencies = [
- "dtoa",
- "linked-hash-map 0.5.4",
- "serde 1.0.123",
- "yaml-rust",
 ]
 
 [[package]]
@@ -3115,17 +3008,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "thread-id"
-version = "3.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7fbf4c9d56b320106cd64fd024dadfa0be7cb4706725fc44a7d7ce952d820c1"
-dependencies = [
- "libc",
- "redox_syscall 0.1.57",
- "winapi",
-]
-
-[[package]]
 name = "thread_local"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3389,12 +3271,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "traitobject"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efd1f82c56340fdf16f2a953d7bda4f8fdffba13d93b00844c25572110b26079"
-
-[[package]]
 name = "trust-dns-client"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3503,15 +3379,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "typemap"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "653be63c80a3296da5551e1bfd2cca35227e13cdd08c6668903ae2f4f77aa1f6"
-dependencies = [
- "unsafe-any",
-]
-
-[[package]]
 name = "typenum"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3567,15 +3434,6 @@ name = "unicode-xid"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
-
-[[package]]
-name = "unsafe-any"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f30360d7979f5e9c6e6cea48af192ea8fab4afb3cf72597154b8f08935bc9c7f"
-dependencies = [
- "traitobject",
-]
 
 [[package]]
 name = "untrusted"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,7 +44,6 @@ dependencies = [
  "headers",
  "http",
  "local_ipaddress",
- "log",
  "machine-uid",
  "menmos-apikit",
  "menmos-client",
@@ -65,7 +64,17 @@ dependencies = [
  "sled 0.34.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile",
  "tokio",
+ "tracing",
  "warp",
+]
+
+[[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -1230,6 +1239,7 @@ version = "0.0.8"
 dependencies = [
  "linked-hash-map 0.5.4",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -1337,6 +1347,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
 
 [[package]]
+name = "matchers"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f099785f7595cc4b4553a174ce30dd7589ef93391ff414dbb67f62392b9e0ce1"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "matches"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1385,8 +1404,8 @@ dependencies = [
  "bincode",
  "branca",
  "chrono",
- "log",
  "serde 1.0.123",
+ "tracing",
  "warp",
 ]
 
@@ -1397,9 +1416,9 @@ dependencies = [
  "anyhow",
  "bytes",
  "futures",
- "log",
  "tokio",
  "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -1478,13 +1497,13 @@ dependencies = [
  "bytes",
  "futures",
  "lfan",
- "log",
  "menmos-betterstreams",
  "menmos-interface",
  "rusoto_core",
  "rusoto_s3",
  "sysinfo",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -1522,10 +1541,12 @@ dependencies = [
  "anyhow",
  "async-trait",
  "clap",
- "log",
- "log4rs",
  "num_cpus",
+ "serde 1.0.123",
+ "serde_json",
  "tokio",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -2263,10 +2284,10 @@ name = "rapidquery"
 version = "0.0.8"
 dependencies = [
  "bitvec 0.20.1",
- "log",
  "nom 6.1.2",
  "serde 1.0.123",
  "snafu",
+ "tracing",
 ]
 
 [[package]]
@@ -2349,6 +2370,15 @@ dependencies = [
  "memchr",
  "regex-syntax",
  "thread_local",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax",
 ]
 
 [[package]]
@@ -2812,6 +2842,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "740223c51853f3145fe7c90360d2d4232f2b62e3449489c207eccde818979982"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3272,7 +3311,19 @@ dependencies = [
  "cfg-if 1.0.0",
  "log",
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c42e6fa53307c8a17e4ccd4dc81cf5ec38db9209f59b222210375b54ee40d1e2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -3292,6 +3343,49 @@ checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
 dependencies = [
  "pin-project",
  "tracing",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6923477a48e41c1951f1999ef8bb5a3023eb723ceadafe78ffb65dc366761e3"
+dependencies = [
+ "lazy_static",
+ "log",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb65ea441fbb84f9f6748fd496cf7f63ec9af5bca94dd86456978d055e8eb28b"
+dependencies = [
+ "serde 1.0.123",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9cbe87a2fa7e35900ce5de20220a582a9483a7063811defce79d7cbd59d4cfe"
+dependencies = [
+ "ansi_term",
+ "chrono",
+ "lazy_static",
+ "matchers",
+ "regex",
+ "serde 1.0.123",
+ "serde_json",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/bin/amphora/Cargo.toml
+++ b/bin/amphora/Cargo.toml
@@ -34,7 +34,6 @@ futures = "0.3"
 headers = "=0.3.3"
 http = "=0.2.3"
 local_ipaddress = "0.1.3"
-log = "0.4"
 machine-uid = "0.2.0"
 menmos-apikit = {version = "^0.0.8"}
 menmos-interface = {version = "^0.0.8"}
@@ -52,4 +51,5 @@ serde = {version = "1", features = ["derive"]}
 serde_json = "1"
 sled = "0.34"
 tokio = {version = "1.2", features = ["full"]}
+tracing = {version = "0.1", features = ["max_level_trace", "release_max_level_info"]}
 warp = {version = "0.3", features = ["tls"]}

--- a/bin/amphora/Cargo.toml
+++ b/bin/amphora/Cargo.toml
@@ -51,5 +51,5 @@ serde = {version = "1", features = ["derive"]}
 serde_json = "1"
 sled = "0.34"
 tokio = {version = "1.2", features = ["full"]}
-tracing = {version = "0.1", features = ["max_level_trace", "release_max_level_info"]}
+tracing = {version = "0.1", features = ["max_level_trace", "release_max_level_debug"]}
 warp = {version = "0.3", features = ["tls"]}

--- a/bin/amphora/src/amphora/config.rs
+++ b/bin/amphora/src/amphora/config.rs
@@ -173,11 +173,6 @@ impl Config {
 
         let cfg: Config = loader.try_into()?;
 
-        println!(
-            "Loaded configuration: \n{}",
-            serde_json::to_string_pretty(&cfg)?
-        );
-
         Ok(cfg)
     }
 }

--- a/bin/amphora/src/amphora/node/index.rs
+++ b/bin/amphora/src/amphora/node/index.rs
@@ -54,7 +54,10 @@ impl Index {
                     match bincode::deserialize::<BlobInfo>(value_ivec.as_ref()) {
                         Ok(e) => Some(e.meta.size),
                         Err(e) => {
-                            log::warn!("failed to deserialize blob during size computation: {}", e);
+                            tracing::warn!(
+                                "failed to deserialize blob during size computation: {}",
+                                e
+                            );
                             None
                         }
                     }

--- a/bin/amphora/src/amphora/node/node_impl.rs
+++ b/bin/amphora/src/amphora/node/node_impl.rs
@@ -138,9 +138,9 @@ impl Storage {
             // TODO: Hold a join handle to this and refuse stopping the storage node until it completes.
             tokio::task::spawn(async move {
                 if let Err(e) = rebuild::execute(params, proxy_cloned, db_cloned).await {
-                    log::error!("rebuild failed: {}", e);
+                    tracing::error!("rebuild failed: {}", e);
                 } else {
-                    log::info!("rebuild complete");
+                    tracing::info!("rebuild complete");
                 }
             });
         }

--- a/bin/amphora/src/amphora/node/stringlock.rs
+++ b/bin/amphora/src/amphora/node/stringlock.rs
@@ -48,7 +48,7 @@ impl StringLock {
     ) {
         if let Some(trigger) = self.cleanup_trigger {
             if guard.len() > trigger {
-                log::debug!(
+                tracing::debug!(
                     "map size is over threshold - file lock cleanup triggered automatically"
                 );
                 self.cleanup_internal(guard);
@@ -77,7 +77,7 @@ impl StringLock {
         guard.retain(|_key, entry| now.duration_since(entry.last_accessed) < self.lifetime);
         let end_time = Instant::now();
 
-        log::debug!(
+        tracing::debug!(
             "file lock cleanup took {}ms",
             end_time.duration_since(now).as_millis()
         );

--- a/bin/amphora/src/amphora/node/transfer/pending.rs
+++ b/bin/amphora/src/amphora/node/transfer/pending.rs
@@ -13,7 +13,7 @@ impl Drop for TransferGuard {
         if let Ok(mut guard) = self.pending_transfers.lock() {
             guard.remove(&self.blob_id);
         } else {
-            log::error!("error during drop: poisoned mutex");
+            tracing::error!("error during drop: poisoned mutex");
         }
     }
 }

--- a/bin/amphora/src/amphora/node/transfer/worker.rs
+++ b/bin/amphora/src/amphora/node/transfer/worker.rs
@@ -141,10 +141,10 @@ impl TransferWorker {
             let mut try_count = 0;
             loop {
                 if let Err(e) = self.transfer_single(&request).await {
-                    log::warn!(
-                        "transferring blob '{}' to '{}' failed: {}",
-                        &request.blob_id,
-                        &request.destination_url,
+                    tracing::warn!(
+                        blob_id= ?request.blob_id,
+                        destination= ?request.destination_url,
+                        "transfer failed: {}",
                         e
                     );
                 } else {
@@ -153,7 +153,7 @@ impl TransferWorker {
 
                 try_count += 1;
                 if try_count >= RETRY_COUNT {
-                    log::error!(
+                    tracing::error!(
                         "exceeded retries while attempting to transfer blob '{}'",
                         request.blob_id
                     );

--- a/bin/amphora/src/amphora/server/filters.rs
+++ b/bin/amphora/src/amphora/server/filters.rs
@@ -44,7 +44,9 @@ where
         .or(fsync(node.clone(), config.clone()))
         .or(flush(node, config))
         .or(version())
-        .with(warp::log("storage::api"))
+        .with(warp::log::custom(
+            |info| tracing::info!(status = ?info.status(), elapsed = ?info.elapsed(), "{} {}", info.method(), info.path()),
+        ))
         .recover(apikit::reject::recover)
 }
 

--- a/bin/amphora/src/amphora/server/handlers/delete.rs
+++ b/bin/amphora/src/amphora/server/handlers/delete.rs
@@ -6,6 +6,7 @@ use interface::StorageNode;
 
 use warp::reply;
 
+#[tracing::instrument(skip(node))]
 pub async fn delete<N: StorageNode>(
     user: UserIdentity,
     node: Arc<N>,

--- a/bin/amphora/src/amphora/server/handlers/flush.rs
+++ b/bin/amphora/src/amphora/server/handlers/flush.rs
@@ -9,6 +9,7 @@ use interface::StorageNode;
 
 use warp::reply;
 
+#[tracing::instrument(skip(node))]
 pub async fn flush<N: StorageNode>(
     user: UserIdentity,
     node: Arc<N>,

--- a/bin/amphora/src/amphora/server/handlers/fsync.rs
+++ b/bin/amphora/src/amphora/server/handlers/fsync.rs
@@ -6,6 +6,7 @@ use interface::StorageNode;
 
 use warp::reply;
 
+#[tracing::instrument(skip(node))]
 pub async fn fsync<N: StorageNode>(
     user: UserIdentity,
     node: Arc<N>,

--- a/bin/amphora/src/amphora/server/handlers/get.rs
+++ b/bin/amphora/src/amphora/server/handlers/get.rs
@@ -56,6 +56,7 @@ fn parse_range_header(value: HeaderValue) -> Result<(Bound<u64>, Bound<u64>)> {
     Ok(ranges[0])
 }
 
+#[tracing::instrument(level = "info", skip(node, range_header))]
 pub async fn get<N: StorageNode>(
     user: UserIdentity,
     node: Arc<N>,

--- a/bin/amphora/src/amphora/server/handlers/health.rs
+++ b/bin/amphora/src/amphora/server/handlers/health.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use interface::StorageNode;
 
+#[tracing::instrument(skip(_node))]
 pub async fn health<N: StorageNode>(_node: Arc<N>) -> Result<impl warp::Reply, warp::Rejection> {
     Ok(apikit::reply::message("healthy"))
 }

--- a/bin/amphora/src/amphora/server/handlers/put.rs
+++ b/bin/amphora/src/amphora/server/handlers/put.rs
@@ -54,6 +54,7 @@ fn prepare_stream(
     Ok(Box::from(io_stream))
 }
 
+#[tracing::instrument(skip(node, mime, meta, body))]
 pub async fn put<N: StorageNode>(
     user: UserIdentity,
     node: Arc<N>,
@@ -72,7 +73,7 @@ pub async fn put<N: StorageNode>(
     if meta_request.blob_type == interface::Type::Directory && stream.is_some() {
         return Err(warp::reject::custom(BadRequest));
     } else if meta_request.blob_type == interface::Type::File && stream.is_none() {
-        log::info!("setting default empty stream");
+        tracing::debug!("setting default empty stream");
         stream = Some(Box::from(futures::stream::empty()))
     }
 

--- a/bin/amphora/src/amphora/server/handlers/update_meta.rs
+++ b/bin/amphora/src/amphora/server/handlers/update_meta.rs
@@ -4,6 +4,7 @@ use apikit::{auth::UserIdentity, reject::InternalServerError};
 
 use interface::{BlobInfoRequest, BlobMetaRequest, StorageNode};
 
+#[tracing::instrument(skip(node, meta_request))]
 pub async fn update_meta<N: StorageNode>(
     user: UserIdentity,
     node: Arc<N>,

--- a/bin/amphora/src/amphora/server/handlers/version.rs
+++ b/bin/amphora/src/amphora/server/handlers/version.rs
@@ -4,6 +4,7 @@ use warp::reply;
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
+#[tracing::instrument]
 pub async fn version() -> Result<reply::Response, warp::Rejection> {
     Ok(apikit::reply::json(&VersionResponse::new(VERSION)))
 }

--- a/bin/amphora/src/amphora/server/handlers/write.rs
+++ b/bin/amphora/src/amphora/server/handlers/write.rs
@@ -22,6 +22,7 @@ fn parse_range_header(value: HeaderValue) -> Result<(Bound<u64>, Bound<u64>)> {
     Ok(ranges[0])
 }
 
+#[tracing::instrument(skip(node, body))]
 pub async fn write<N: StorageNode>(
     user: UserIdentity,
     node: Arc<N>,

--- a/bin/amphora/src/amphora/server/server_impl.rs
+++ b/bin/amphora/src/amphora/server/server_impl.rs
@@ -57,6 +57,8 @@ where
             h
         };
 
+        tracing::info!("amphora is up");
+
         Self {
             _node: node,
             handle: ServerProcess {

--- a/bin/amphora/src/amphora/server/server_impl.rs
+++ b/bin/amphora/src/amphora/server/server_impl.rs
@@ -31,7 +31,7 @@ where
         let warp_server = warp::serve(filters::all(node.clone(), config.clone()));
 
         let join_handle = if let Some(certs) = cert_paths {
-            log::info!("starting https layer");
+            tracing::debug!("starting https layer");
             let h = spawn(
                 warp_server
                     .tls()
@@ -42,10 +42,10 @@ where
                     })
                     .1,
             );
-            log::info!("https layer started");
+            tracing::debug!("https layer started");
             h
         } else {
-            log::info!("starting http layer");
+            tracing::debug!("starting http layer");
             let h = spawn(
                 warp_server
                     .bind_with_graceful_shutdown(([0, 0, 0, 0], config.server.port), async {
@@ -53,7 +53,7 @@ where
                     })
                     .1,
             );
-            log::info!("http layer started");
+            tracing::debug!("http layer started");
             h
         };
 

--- a/bin/menmosd/Cargo.toml
+++ b/bin/menmosd/Cargo.toml
@@ -36,12 +36,10 @@ chrono = {version = "0.4", features = ["serde"]}
 clap = "3.0.0-beta.2"
 config = {git = "https://github.com/dalloriam/config-rs", branch = "parse-env-numbers"}
 dirs = "3"
-env_logger = "0.8"
 external-ip = "=4.1.0"
 futures = "0.3"
 headers = "=0.3.3"
 ipnetwork = "0.17"
-log = "0.4"
 menmos-antidns = {version = "^0.0.8"}
 menmos-apikit = {version = "^0.0.8"}
 menmos-interface = {version = "^0.0.8"}
@@ -55,6 +53,7 @@ rust-argon2 = "0.8"
 serde = {version = "1", features = ["derive"]}
 serde_json = "1"
 sled = {git = "https://github.com/spacejam/sled", branch = "main"}
+tracing = {version = "0.1", features = ["max_level_trace", "release_max_level_debug"]}
 tokio = {version = "1.2", features = ["full"]}
 uuid = { version = "0.8", features = ["serde", "v4"] }
 warp = {version = "0.3", features = ["tls"]}

--- a/bin/menmosd/src/menmosd/config.rs
+++ b/bin/menmosd/src/menmosd/config.rs
@@ -156,11 +156,6 @@ impl Config {
 
         let cfg: Config = loader.try_into()?;
 
-        println!(
-            "Loaded configuration: \n{}",
-            serde_json::to_string_pretty(&cfg)?
-        );
-
         Ok(cfg)
     }
 }

--- a/bin/menmosd/src/menmosd/node/service/admin.rs
+++ b/bin/menmosd/src/menmosd/node/service/admin.rs
@@ -52,9 +52,9 @@ impl interface::NodeAdminController for NodeAdminService {
 
     async fn start_rebuild(&self) -> Result<()> {
         let storage_nodes = self.router.list_nodes().await;
-        log::info!("starting rebuild for {} nodes", storage_nodes.len());
+        tracing::info!(node_count = storage_nodes.len(), "starting rebuild");
 
-        log::debug!("nuking the whole index");
+        tracing::debug!("nuking the whole index");
         self.indexer_service.clear().await?;
 
         let mut rebuild_queue_guard = self.rebuild_queue.lock().map_err(|e| anyhow!("{}", e))?;
@@ -66,7 +66,7 @@ impl interface::NodeAdminController for NodeAdminService {
     async fn rebuild_complete(&self, storage_node_id: &str) -> Result<()> {
         let mut rebuild_queue_guard = self.rebuild_queue.lock().map_err(|e| anyhow!("{}", e))?;
         rebuild_queue_guard.retain(|item| item.id != storage_node_id);
-        log::info!("finished rebuild for node id={}", storage_node_id);
+        tracing::info!("finished rebuild for node id={}", storage_node_id);
         Ok(())
     }
 

--- a/bin/menmosd/src/menmosd/node/service/indexer.rs
+++ b/bin/menmosd/src/menmosd/node/service/indexer.rs
@@ -105,7 +105,7 @@ impl interface::BlobIndexer for IndexerService {
                 "blob node is different from the storage node id that requested deletion"
             )
         } else {
-            log::error!("no node found for blob_id={}", blob_id)
+            tracing::error!("no node found for blob_id={}", blob_id);
         }
 
         // This is tricky, because since our internal document IDs are sequential, we can't just delete the blob from the index and call it a day.

--- a/bin/menmosd/src/menmosd/node/store/documents.rs
+++ b/bin/menmosd/src/menmosd/node/store/documents.rs
@@ -55,10 +55,10 @@ impl SledDocumentIdStore {
 #[async_trait]
 impl Flush for SledDocumentIdStore {
     async fn flush(&self) -> Result<()> {
-        log::debug!("beginning flush");
+        tracing::debug!("beginning flush");
         self.doc_map.flush_async().await?;
         self.doc_reverse_map.flush_async().await?;
-        log::debug!("flush complete");
+        tracing::debug!("flush complete");
         Ok(())
     }
 }
@@ -141,7 +141,7 @@ impl DocumentIdStore for SledDocumentIdStore {
         self.doc_map.clear()?;
         self.doc_reverse_map.clear()?;
         self.recycling_store.clear()?;
-        log::debug!("document index destroyed");
+        tracing::debug!("document index destroyed");
         Ok(())
     }
 }

--- a/bin/menmosd/src/menmosd/node/store/storage.rs
+++ b/bin/menmosd/src/menmosd/node/store/storage.rs
@@ -53,7 +53,7 @@ impl StorageMappingStore for SledStorageMappingStore {
 
     fn clear(&self) -> Result<()> {
         self.tree.clear()?;
-        log::debug!("storage index destroyed");
+        tracing::debug!("storage index destroyed");
         Ok(())
     }
 }

--- a/bin/menmosd/src/menmosd/server/filters/mod.rs
+++ b/bin/menmosd/src/menmosd/server/filters/mod.rs
@@ -25,7 +25,9 @@ pub fn all(
         .or(auth::all(context.clone()))
         .or(routing::all(context))
         .recover(apikit::reject::recover)
-        .with(warp::log("directory::api"))
+        .with(warp::log::custom(
+            |info| tracing::info!(status = ?info.status(), elapsed = ?info.elapsed(), "{} {}", info.method(), info.path()),
+        ))
 }
 
 #[cfg(debug_assertions)]
@@ -45,6 +47,8 @@ pub fn all(
                 .allow_headers(vec!["Content-Type", "x-blob-meta", "Authorization"])
                 .allow_methods(vec!["GET", "POST", "DELETE", "PUT", "OPTIONS"]),
         )
-        .with(warp::log("directory::api"))
+        .with(warp::log::custom(
+            |info| tracing::info!(status = ?info.status(), elapsed = ?info.elapsed(), "{} {}", info.method(), info.path()),
+        ))
         .recover(apikit::reject::recover)
 }

--- a/bin/menmosd/src/menmosd/server/handlers/admin/flush.rs
+++ b/bin/menmosd/src/menmosd/server/handlers/admin/flush.rs
@@ -7,6 +7,7 @@ use warp::reply;
 
 use crate::server::Context;
 
+#[tracing::instrument(skip(context))]
 pub async fn flush(
     user: UserIdentity,
     context: Context,

--- a/bin/menmosd/src/menmosd/server/handlers/admin/health.rs
+++ b/bin/menmosd/src/menmosd/server/handlers/admin/health.rs
@@ -1,3 +1,4 @@
+#[tracing::instrument]
 pub async fn health() -> Result<impl warp::Reply, warp::Rejection> {
     Ok(apikit::reply::message("healthy"))
 }

--- a/bin/menmosd/src/menmosd/server/handlers/admin/rebuild.rs
+++ b/bin/menmosd/src/menmosd/server/handlers/admin/rebuild.rs
@@ -5,6 +5,7 @@ use warp::reply;
 
 use crate::server::Context;
 
+#[tracing::instrument(skip(context))]
 pub async fn rebuild(
     user: UserIdentity,
     context: Context,

--- a/bin/menmosd/src/menmosd/server/handlers/admin/rebuild_complete.rs
+++ b/bin/menmosd/src/menmosd/server/handlers/admin/rebuild_complete.rs
@@ -5,6 +5,7 @@ use warp::reply;
 
 use crate::server::Context;
 
+#[tracing::instrument(skip(context))]
 pub async fn rebuild_complete(
     identity: StorageNodeIdentity,
     context: Context,

--- a/bin/menmosd/src/menmosd/server/handlers/admin/version.rs
+++ b/bin/menmosd/src/menmosd/server/handlers/admin/version.rs
@@ -6,6 +6,7 @@ use warp::reply;
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
+#[tracing::instrument]
 pub async fn version(_user: UserIdentity) -> Result<reply::Response, warp::Rejection> {
     Ok(apikit::reply::json(&VersionResponse::new(VERSION)))
 }

--- a/bin/menmosd/src/menmosd/server/handlers/auth/login.rs
+++ b/bin/menmosd/src/menmosd/server/handlers/auth/login.rs
@@ -7,6 +7,7 @@ use warp::reply;
 
 use crate::server::Context;
 
+#[tracing::instrument(skip(context), fields(user = ?request.username))]
 pub async fn login(
     context: Context,
     request: LoginRequest,

--- a/bin/menmosd/src/menmosd/server/handlers/auth/register.rs
+++ b/bin/menmosd/src/menmosd/server/handlers/auth/register.rs
@@ -12,7 +12,7 @@ pub async fn register(
     context: Context,
     request: RegisterRequest,
 ) -> Result<reply::Response, warp::Rejection> {
-    log::debug!("identity: {:?}", identity);
+    tracing::debug!("identity: {:?}", identity);
     if !identity.admin {
         return Err(Forbidden.into());
     }

--- a/bin/menmosd/src/menmosd/server/handlers/blob/delete.rs
+++ b/bin/menmosd/src/menmosd/server/handlers/blob/delete.rs
@@ -8,6 +8,7 @@ use warp::{reply, Reply};
 use crate::network::get_storage_node_address;
 use crate::server::Context;
 
+#[tracing::instrument(skip(context, addr))]
 pub async fn delete(
     user: UserIdentity,
     context: Context,

--- a/bin/menmosd/src/menmosd/server/handlers/blob/fsync.rs
+++ b/bin/menmosd/src/menmosd/server/handlers/blob/fsync.rs
@@ -10,6 +10,7 @@ use warp::Reply;
 use crate::network::get_storage_node_address;
 use crate::server::Context;
 
+#[tracing::instrument(skip(context, addr))]
 pub async fn fsync(
     _user: UserIdentity,
     context: Context,

--- a/bin/menmosd/src/menmosd/server/handlers/blob/get.rs
+++ b/bin/menmosd/src/menmosd/server/handlers/blob/get.rs
@@ -10,6 +10,7 @@ use warp::{reply, Reply};
 use crate::network::get_storage_node_address;
 use crate::server::Context;
 
+#[tracing::instrument(skip(context, addr))]
 pub async fn get(
     _user: UserIdentity,
     context: Context,

--- a/bin/menmosd/src/menmosd/server/handlers/blob/put.rs
+++ b/bin/menmosd/src/menmosd/server/handlers/blob/put.rs
@@ -21,6 +21,7 @@ fn parse_metadata(header_value: String) -> Result<BlobMetaRequest> {
     Ok(meta)
 }
 
+#[tracing::instrument(skip(context, meta, addr))]
 pub async fn put(
     user: UserIdentity,
     context: Context,
@@ -49,7 +50,7 @@ pub async fn put(
     )
     .map_err(InternalServerError::from)?;
 
-    log::info!("redirecting to {}", &node_address);
+    tracing::debug!("redirecting to {}", &node_address);
 
     Ok(warp::redirect::temporary(node_address).into_response())
 }

--- a/bin/menmosd/src/menmosd/server/handlers/blob/update.rs
+++ b/bin/menmosd/src/menmosd/server/handlers/blob/update.rs
@@ -10,6 +10,7 @@ use warp::{reply, Reply};
 use crate::network::get_storage_node_address;
 use crate::server::Context;
 
+#[tracing::instrument(skip(context, addr))]
 pub async fn update(
     user: UserIdentity,
     context: Context,

--- a/bin/menmosd/src/menmosd/server/handlers/blob/write.rs
+++ b/bin/menmosd/src/menmosd/server/handlers/blob/write.rs
@@ -14,6 +14,7 @@ use warp::{reply, Reply};
 use crate::network::get_storage_node_address;
 use crate::server::Context;
 
+#[tracing::instrument(skip(context, addr, _body))]
 pub async fn write(
     _user: UserIdentity,
     context: Context,

--- a/bin/menmosd/src/menmosd/server/handlers/blobmeta/create.rs
+++ b/bin/menmosd/src/menmosd/server/handlers/blobmeta/create.rs
@@ -7,6 +7,7 @@ use warp::reply;
 
 use crate::server::Context;
 
+#[tracing::instrument(skip(context, blob_info))]
 pub async fn create(
     identity: StorageNodeIdentity,
     context: Context,

--- a/bin/menmosd/src/menmosd/server/handlers/blobmeta/delete.rs
+++ b/bin/menmosd/src/menmosd/server/handlers/blobmeta/delete.rs
@@ -5,6 +5,7 @@ use warp::reply;
 
 use crate::server::Context;
 
+#[tracing::instrument(skip(context))]
 pub async fn delete(
     identity: StorageNodeIdentity,
     context: Context,

--- a/bin/menmosd/src/menmosd/server/handlers/blobmeta/get.rs
+++ b/bin/menmosd/src/menmosd/server/handlers/blobmeta/get.rs
@@ -6,6 +6,7 @@ use warp::reply;
 
 use crate::server::Context;
 
+#[tracing::instrument(skip(context))]
 pub async fn get(
     user: UserIdentity,
     context: Context,

--- a/bin/menmosd/src/menmosd/server/handlers/blobmeta/list.rs
+++ b/bin/menmosd/src/menmosd/server/handlers/blobmeta/list.rs
@@ -6,11 +6,17 @@ use warp::reply;
 
 use crate::server::Context;
 
+#[tracing::instrument(skip(context, req))]
 pub async fn list(
     user: UserIdentity,
     context: Context,
     req: ListMetadataRequest,
 ) -> Result<reply::Response, warp::Rejection> {
+    tracing::trace!(
+        tags = %&req.tags.clone().unwrap_or_default().join(","),
+        keys = %&req.meta_keys.clone().unwrap_or_default().join(","),
+        "list metadata request"
+    );
     let response = context
         .node
         .query()

--- a/bin/menmosd/src/menmosd/server/handlers/blobmeta/update.rs
+++ b/bin/menmosd/src/menmosd/server/handlers/blobmeta/update.rs
@@ -11,6 +11,7 @@ use warp::Reply;
 use crate::network::get_storage_node_address;
 use crate::server::Context;
 
+#[tracing::instrument(skip(context, _meta, addr))]
 pub async fn update(
     _user: UserIdentity,
     context: Context,

--- a/bin/menmosd/src/menmosd/server/handlers/query/exec_query.rs
+++ b/bin/menmosd/src/menmosd/server/handlers/query/exec_query.rs
@@ -65,7 +65,7 @@ async fn fetch_urls(
                 new_hits.push(hit.clone());
             }
             Err(e) => {
-                log::warn!("error getting blob uri for {}: {}", hit.id, e);
+                tracing::warn!(blob_id = ?hit.id, "error getting blob uri: {}", e);
             }
         }
     }
@@ -76,6 +76,7 @@ async fn fetch_urls(
     Ok(())
 }
 
+#[tracing::instrument(skip(context, addr, query_request))]
 pub async fn query(
     user: UserIdentity,
     context: Context,
@@ -85,6 +86,7 @@ pub async fn query(
     let socket_addr = addr.ok_or_else(|| InternalServerError::from("missing socket address"))?;
 
     let query = Query::try_from(query_request).map_err(|_| BadRequest)?;
+    tracing::debug!(query = ?query.expression, "query request");
 
     let mut query_response = context
         .node

--- a/bin/menmosd/src/menmosd/server/handlers/routing/delete.rs
+++ b/bin/menmosd/src/menmosd/server/handlers/routing/delete.rs
@@ -5,6 +5,7 @@ use warp::reply;
 
 use crate::server::context::Context;
 
+#[tracing::instrument(skip(context))]
 pub async fn delete(
     user: UserIdentity,
     context: Context,

--- a/bin/menmosd/src/menmosd/server/handlers/routing/get.rs
+++ b/bin/menmosd/src/menmosd/server/handlers/routing/get.rs
@@ -6,6 +6,7 @@ use warp::reply;
 
 use crate::server::context::Context;
 
+#[tracing::instrument(skip(context))]
 pub async fn get(user: UserIdentity, context: Context) -> Result<reply::Response, warp::Rejection> {
     let routing_config = context
         .node

--- a/bin/menmosd/src/menmosd/server/handlers/routing/set.rs
+++ b/bin/menmosd/src/menmosd/server/handlers/routing/set.rs
@@ -7,6 +7,7 @@ use warp::reply;
 
 use crate::server::context::Context;
 
+#[tracing::instrument(skip(context))]
 pub async fn set(
     user: UserIdentity,
     context: Context,

--- a/bin/menmosd/src/menmosd/server/handlers/storage/list.rs
+++ b/bin/menmosd/src/menmosd/server/handlers/storage/list.rs
@@ -6,6 +6,7 @@ use warp::reply;
 
 use crate::server::context::Context;
 
+#[tracing::instrument(skip(context))]
 pub async fn list(
     _user: UserIdentity,
     context: Context,

--- a/bin/menmosd/src/menmosd/server/handlers/storage/put.rs
+++ b/bin/menmosd/src/menmosd/server/handlers/storage/put.rs
@@ -34,6 +34,7 @@ fn get_request_from_move_info(
     })
 }
 
+#[tracing::instrument(skip(context, addr, info))]
 pub async fn put(
     identity: apikit::auth::StorageNodeIdentity,
     context: Context,

--- a/bin/menmosd/src/menmosd/server/server_impl.rs
+++ b/bin/menmosd/src/menmosd/server/server_impl.rs
@@ -39,12 +39,12 @@ impl Server {
                 match use_tls(node_cloned, config, https_cfg, stop_rx).await {
                     Ok(_) => {}
                     Err(e) => {
-                        log::error!("async error: {}", e)
+                        tracing::error!("async error: {}", e)
                     }
                 }
             }),
             ServerSetting::Http(http_cfg) => {
-                log::info!("starting http layer");
+                tracing::debug!("starting http layer");
                 let server_context = Context {
                     node: node.clone(),
                     config,
@@ -56,7 +56,8 @@ impl Server {
                         stop_rx.recv().await;
                     });
 
-                log::info!("http layer started");
+                tracing::debug!("http layer started");
+                tracing::info!("menmosd is up");
                 spawn(srv)
             }
         };
@@ -69,11 +70,11 @@ impl Server {
     }
 
     pub async fn stop(self) -> Result<()> {
-        log::info!("requesting to quit");
+        tracing::info!("requesting to quit");
         self.stop_tx.send(()).await?;
         self.handle.await?;
         self.node.flush().await?;
-        log::info!("exited");
+        tracing::info!("exited");
 
         Ok(())
     }

--- a/crates/lfan/Cargo.toml
+++ b/crates/lfan/Cargo.toml
@@ -15,3 +15,4 @@ async = ["tokio"]
 [dependencies]
 linked-hash-map = "0.5"
 tokio = {version = "1.2", features = ["sync"], optional = true}
+tracing = {version = "0.1", features = ["max_level_trace", "release_max_level_info"]}

--- a/crates/lfan/Cargo.toml
+++ b/crates/lfan/Cargo.toml
@@ -15,4 +15,4 @@ async = ["tokio"]
 [dependencies]
 linked-hash-map = "0.5"
 tokio = {version = "1.2", features = ["sync"], optional = true}
-tracing = {version = "0.1", features = ["max_level_trace", "release_max_level_info"]}
+tracing = {version = "0.1", features = ["max_level_trace", "release_max_level_debug"]}

--- a/crates/menmos-antidns/Cargo.toml
+++ b/crates/menmos-antidns/Cargo.toml
@@ -17,8 +17,8 @@ portpicker = "0.1"
 trust-dns-resolver = "0.20"
 
 [dependencies]
-log = "0.4"
 nom = {version = "6.1"}
 serde = {version = "1.0", features = ["derive"]}
 snafu = "0.6"
 tokio = {version = "1.2", features = ["full"]}
+tracing = {version = "0.1", features = ["max_level_trace", "release_max_level_debug"]}

--- a/crates/menmos-antidns/src/packet.rs
+++ b/crates/menmos-antidns/src/packet.rs
@@ -34,7 +34,7 @@ impl DnsPacket {
     }
 
     pub fn from_buffer(buffer: &mut BytePacketBuffer) -> Result<DnsPacket> {
-        log::trace!("deserializing packet from buffer");
+        tracing::trace!("deserializing packet from buffer");
 
         let mut result = DnsPacket::new();
         result.header.read(buffer).context(FailedToParseHeader)?;
@@ -46,7 +46,7 @@ impl DnsPacket {
         }
 
         for i in 0..result.header.answers {
-            log::trace!("deserializing answer {}", i);
+            tracing::trace!("deserializing answer {}", i);
             let rec = DnsRecord::read(buffer).context(FailedToParseRecord)?;
             result.answers.push(rec);
         }

--- a/crates/menmos-antidns/src/record.rs
+++ b/crates/menmos-antidns/src/record.rs
@@ -144,18 +144,18 @@ impl DnsRecord {
                 })
             }
             QueryType::TXT => {
-                log::debug!("deserializing TXT record");
+                tracing::debug!("deserializing TXT record");
 
                 let mut text = Vec::new();
                 loop {
                     if buffer.pos() == 512 {
-                        log::trace!("reached EOF -> TXT record finished");
+                        tracing::trace!("reached EOF -> TXT record finished");
                         break;
                     }
 
                     let string_length = buffer.read().context(InvalidBuffer)?;
                     if string_length == 0 {
-                        log::trace!("got null terminator -> TXT record finished");
+                        tracing::trace!("got null terminator -> TXT record finished");
                         break;
                     }
 
@@ -164,7 +164,7 @@ impl DnsRecord {
                             .get_range(buffer.pos(), string_length as usize)
                             .context(InvalidBuffer)?;
 
-                        log::debug!(
+                        tracing::debug!(
                             "got TXT string: '{}'",
                             String::from_utf8_lossy(string_bytes)
                         );
@@ -285,7 +285,7 @@ impl DnsRecord {
                 data_len,
                 ref text,
             } => {
-                log::debug!("serializing TXT record");
+                tracing::debug!("serializing TXT record");
                 buffer
                     .write_bytes(domain_bytes.as_ref())
                     .context(InvalidBuffer)?;
@@ -300,7 +300,7 @@ impl DnsRecord {
                 for string in text.iter() {
                     ensure!(string.len() <= 255, StringTooLong);
 
-                    log::trace!(
+                    tracing::trace!(
                         "writing string '{}' with length {}",
                         String::from_utf8_lossy(string.as_ref()),
                         string.len()
@@ -328,10 +328,10 @@ impl DnsRecord {
                 }
             }
             DnsRecord::CAA {} => {
-                log::debug!("writing nothing instead of CAA record");
+                tracing::debug!("writing nothing instead of CAA record");
             }
             DnsRecord::UNKNOWN { .. } => {
-                log::warn!("skipping record: {:?}", self);
+                tracing::warn!("skipping record: {:?}", self);
             }
         }
 

--- a/crates/menmos-antidns/src/resolver.rs
+++ b/crates/menmos-antidns/src/resolver.rs
@@ -13,7 +13,7 @@ pub enum ResolveError {
 type Result<T> = std::result::Result<T, ResolveError>;
 
 fn in_house_resolution(qname: &str, ip: IpAddr) -> Result<DnsPacket> {
-    log::info!("resolving {} in-house to {}", qname, ip);
+    tracing::info!("resolving {} in-house to {}", qname, ip);
 
     match ip {
         IpAddr::V4(ip) => {
@@ -36,7 +36,7 @@ fn in_house_resolution(qname: &str, ip: IpAddr) -> Result<DnsPacket> {
 }
 
 pub async fn lookup(qname: &str, qtype: QueryType, cfg: &Config) -> Result<Option<DnsPacket>> {
-    log::debug!("lookup [{:?}] on {}", qtype, qname);
+    tracing::debug!("lookup [{:?}] on {}", qtype, qname);
     // Attempt to forward A queries that have a serialized IP in their domain to the IP itself.
     if qtype == QueryType::A {
         if let Ok(ip) = extract::ip_address_from_url(qname) {
@@ -51,11 +51,11 @@ pub async fn lookup(qname: &str, qtype: QueryType, cfg: &Config) -> Result<Optio
         // This means that any public CA has the authority to emit certificates for your domain.
         // If you really _need_ CAA, you should probably be using something more serious than this
         // embedded DNS server.
-        log::debug!("skipping resolution of a CAA query");
+        tracing::debug!("skipping resolution of a CAA query");
         return Ok(Some(DnsPacket::new()));
     }
     if qtype == QueryType::AAAA && qname.ends_with(&cfg.root_domain) {
-        log::debug!("returning blank AAAA response");
+        tracing::debug!("returning blank AAAA response");
         return Ok(Some(DnsPacket::new()));
     }
 

--- a/crates/menmos-apikit/Cargo.toml
+++ b/crates/menmos-apikit/Cargo.toml
@@ -17,6 +17,6 @@ anyhow = "1"
 bincode = "1.3"
 branca = "0.10"
 chrono = "0.4"
-log = "0.4"
 serde = {version = "1", features = ["derive"]}
+tracing = {version = "0.1", features = ["max_level_trace", "release_max_level_info"]}
 warp = {version = "0.3", features = ["tls"]}

--- a/crates/menmos-apikit/Cargo.toml
+++ b/crates/menmos-apikit/Cargo.toml
@@ -18,5 +18,5 @@ bincode = "1.3"
 branca = "0.10"
 chrono = "0.4"
 serde = {version = "1", features = ["derive"]}
-tracing = {version = "0.1", features = ["max_level_trace", "release_max_level_info"]}
+tracing = {version = "0.1", features = ["max_level_trace", "release_max_level_debug"]}
 warp = {version = "0.3", features = ["tls"]}

--- a/crates/menmos-apikit/src/auth.rs
+++ b/crates/menmos-apikit/src/auth.rs
@@ -1,4 +1,6 @@
 //! Everything related to authentication.
+use std::fmt::Debug;
+
 use branca::Branca;
 
 use serde::de::DeserializeOwned;
@@ -53,11 +55,21 @@ pub struct StorageNodeIdentity {
 /// Represents a user identity.
 ///
 /// This is the body of user tokens.
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Deserialize, Serialize)]
 pub struct UserIdentity {
     pub username: String,
     pub admin: bool,
     pub blobs_whitelist: Option<Vec<String>>, // If none, all blobs are allowed.
+}
+
+impl Debug for UserIdentity {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if self.admin {
+            write!(f, "{} (admin)", &self.username)
+        } else {
+            write!(f, "{}", &self.username)
+        }
+    }
 }
 
 #[derive(Debug, Default, Deserialize, Serialize)]
@@ -90,7 +102,7 @@ fn strip_bearer(tok: &str) -> Result<&str, warp::Rejection> {
     const BEARER: &str = "Bearer ";
 
     if !tok.starts_with(BEARER) {
-        log::debug!("invalid token");
+        tracing::debug!("invalid token");
         return Err(reject::Forbidden.into());
     }
 

--- a/crates/menmos-apikit/src/auth.rs
+++ b/crates/menmos-apikit/src/auth.rs
@@ -52,6 +52,12 @@ pub struct StorageNodeIdentity {
     pub id: String,
 }
 
+impl Debug for StorageNodeIdentity {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "storage({})", &self.id)
+    }
+}
+
 /// Represents a user identity.
 ///
 /// This is the body of user tokens.

--- a/crates/menmos-apikit/src/reject.rs
+++ b/crates/menmos-apikit/src/reject.rs
@@ -48,16 +48,19 @@ impl reject::Reject for NotFound {}
 /// Converts all remaining unknown rejections to an HTTP 500.
 pub async fn recover(err: warp::Rejection) -> Result<impl warp::Reply, Infallible> {
     if let Some(Forbidden) = err.find() {
+        tracing::info!("rejection: Forbidden");
         Ok(reply::error(MESSAGE_FORBIDDEN, StatusCode::FORBIDDEN))
     } else if let Some(BadRequest) = err.find() {
+        tracing::info!("rejection: BadRequest");
         Ok(reply::error(MESSAGE_BAD_REQUEST, StatusCode::BAD_REQUEST))
     } else if let Some(InternalServerError { message }) = err.find() {
-        log::error!("error: {:?}", message);
+        tracing::error!("error: {}", message);
         Ok(reply::error(message, StatusCode::INTERNAL_SERVER_ERROR))
-    } else if let Some(_e) = err.find::<warp::filters::body::BodyDeserializeError>() {
+    } else if let Some(e) = err.find::<warp::filters::body::BodyDeserializeError>() {
+        tracing::info!(info = ?e.to_string(), "rejection: BadRequest");
         Ok(reply::error(MESSAGE_BAD_REQUEST, StatusCode::BAD_REQUEST))
     } else {
-        log::warn!("unhandled rejection: {:?}", err);
+        tracing::error!("unhandled rejection: {:?}", err);
         Ok(reply::error(
             "unknown error",
             StatusCode::INTERNAL_SERVER_ERROR,

--- a/crates/menmos-betterstreams/Cargo.toml
+++ b/crates/menmos-betterstreams/Cargo.toml
@@ -20,4 +20,4 @@ bytes = "1.0"
 futures = "0.3"
 tokio = {version = "1", features = ["io-util", "fs"]}
 tokio-util = {version = "0.6.3", features = ["codec", "io"]}
-tracing = {version = "0.1", features = ["max_level_trace", "release_max_level_info"]}
+tracing = {version = "0.1", features = ["max_level_trace", "release_max_level_debug"]}

--- a/crates/menmos-betterstreams/Cargo.toml
+++ b/crates/menmos-betterstreams/Cargo.toml
@@ -18,6 +18,6 @@ tokio = {version = "1", features = ["io-util", "fs", "rt-multi-thread"]}
 anyhow = "1"
 bytes = "1.0"
 futures = "0.3"
-log = "0.4"
 tokio = {version = "1", features = ["io-util", "fs"]}
 tokio-util = {version = "0.6.3", features = ["codec", "io"]}
+tracing = {version = "0.1", features = ["max_level_trace", "release_max_level_info"]}

--- a/crates/menmos-betterstreams/src/fs.rs
+++ b/crates/menmos-betterstreams/src/fs.rs
@@ -117,7 +117,7 @@ pub async fn read_range<P: AsRef<Path>>(
             let mut f = match result {
                 Ok(f) => f,
                 Err(f) => {
-                    log::error!("unexpected state in stream: {}", f);
+                    tracing::error!("unexpected state in stream: {}", f);
                     panic!("find out why this is reached");
                 }
             };
@@ -132,13 +132,13 @@ pub async fn read_range<P: AsRef<Path>>(
                 let n = match ready!(poll_read_buf(Pin::new(&mut f), cx, &mut buf)) {
                     Ok(n) => n as u64,
                     Err(err) => {
-                        log::trace!("file read error: {}", err);
+                        tracing::debug!("file read error: {}", err);
                         return Poll::Ready(Some(Err(err)));
                     }
                 };
 
                 if n == 0 {
-                    log::trace!("file read found EOF before expected length");
+                    tracing::debug!("file read found EOF before expected length");
                     return Poll::Ready(None);
                 }
 

--- a/crates/menmos-client/Cargo.toml
+++ b/crates/menmos-client/Cargo.toml
@@ -14,7 +14,6 @@ bytes = "1"
 dirs = "3"
 futures = "0.3"
 hyper = "0.14"
-log = "0.4"
 menmos-apikit = {version = "^0.0.8"}
 menmos-interface = {version = "^0.0.8"}
 menmos-protocol = {version = "^0.0.8"}
@@ -25,3 +24,4 @@ serde_json = "1"
 snafu = "0.6"
 tokio = {version = "1.2", features = ["full"]}
 toml = "0.5"
+tracing = {version = "0.1", features = ["max_level_trace", "release_max_level_debug"]}

--- a/crates/menmos-client/src/client.rs
+++ b/crates/menmos-client/src/client.rs
@@ -231,7 +231,7 @@ impl Client {
             {
                 Ok(r) => return Ok(r),
                 Err(e) => {
-                    log::debug!(
+                    tracing::debug!(
                         "request failed: {} - retrying in {}ms",
                         e,
                         self.retry_interval.as_millis()
@@ -296,7 +296,7 @@ impl Client {
             .ok_or(ClientError::MissingRedirect)?;
 
         let new_url = String::from_utf8_lossy(new_location.as_bytes());
-        log::debug!("redirect to {}", new_url);
+        tracing::debug!("redirect to {}", new_url);
         Ok(new_url.to_string())
     }
 

--- a/crates/menmos-repository/Cargo.toml
+++ b/crates/menmos-repository/Cargo.toml
@@ -18,10 +18,10 @@ async-trait = "0.1.42"
 bytes = "1"
 futures = "0.3"
 lfan = {version = "^0.0.8", features = ["async"]}
-log = "0.4"
 menmos-betterstreams = {version = "^0.0.8"}
 menmos-interface = {version = "^0.0.8"}
 rusoto_core = "0.46"
 rusoto_s3 = "0.46"
 sysinfo = "0.20"
 tokio = {version = "1.2", features = ["full"]}
+tracing = {version = "0.1", features = ["max_level_trace", "release_max_level_info"]}

--- a/crates/menmos-repository/Cargo.toml
+++ b/crates/menmos-repository/Cargo.toml
@@ -24,4 +24,4 @@ rusoto_core = "0.46"
 rusoto_s3 = "0.46"
 sysinfo = "0.20"
 tokio = {version = "1.2", features = ["full"]}
-tracing = {version = "0.1", features = ["max_level_trace", "release_max_level_info"]}
+tracing = {version = "0.1", features = ["max_level_trace", "release_max_level_debug"]}

--- a/crates/menmos-repository/src/s3/repo.rs
+++ b/crates/menmos-repository/src/s3/repo.rs
@@ -169,7 +169,7 @@ impl Repository for S3Repository {
     }
 
     async fn delete(&self, blob_id: &str) -> Result<()> {
-        self.file_cache.invalidate(&blob_id).await?;
+        self.file_cache.invalidate(blob_id).await?;
 
         let delete_request = DeleteObjectRequest {
             bucket: self.bucket.clone(),

--- a/crates/menmos-repository/src/s3/repo.rs
+++ b/crates/menmos-repository/src/s3/repo.rs
@@ -186,7 +186,6 @@ impl Repository for S3Repository {
         // FIXME: Trigger fsync asynchronously so it doesn't block the call.
         // FIXME: Trigger fsync periodically for cache keys, and every time on cache eviction.
         if let Some(path) = self.file_cache.contains(&id).await {
-            log::info!("begin fsync on {}", &id);
             let f = fs::File::open(&path).await?;
             let file_length = path.metadata()?.len();
             let _result = self
@@ -201,7 +200,7 @@ impl Repository for S3Repository {
                     ..Default::default()
                 })
                 .await?;
-            log::info!("fsync on {} complete", id);
+            tracing::debug!(file_length = file_length, "complete");
         }
 
         Ok(())

--- a/crates/menmos-testing/Cargo.toml
+++ b/crates/menmos-testing/Cargo.toml
@@ -15,15 +15,16 @@ path = "src/lib.rs"
 amphora = {path = "../../bin/amphora"}
 anyhow = "1"
 futures = "0.3"
-log = "0.4"
-log4rs = "1"
 menmosd = {path = "../../bin/menmosd"}
 menmos-apikit = {version = "^0.0.8"}
 menmos-client = {version = "^0.0.8"}
 menmos-protocol = {version = "^0.0.8"}
 menmos-interface = {version = "^0.0.8"}
+menmos-xecute = {version = "^0.0.8"}
 portpicker = "0.1"
 reqwest = {version = "0.11", features = ["json"]}
 serde_json = "1"
 tempfile = "3.2"
 tokio = {version = "1.2", features = ["full"]}
+tracing = {version = "0.1", features = ["max_level_trace", "release_max_level_debug"]}
+tracing-subscriber = "0.2"

--- a/crates/menmos-testing/src/fixtures/mod.rs
+++ b/crates/menmos-testing/src/fixtures/mod.rs
@@ -6,9 +6,6 @@ use std::time::Duration;
 use anyhow::{anyhow, ensure, Result};
 
 use interface::StorageNodeInfo;
-use log::LevelFilter;
-use log4rs::append::console::ConsoleAppender;
-use log4rs::config::{Appender, Config as LogConfig, Root};
 use menmos_client::{Client, Meta};
 use menmosd::config::{HttpParameters, ServerSetting};
 use menmosd::{Config, Server};
@@ -21,12 +18,7 @@ static INIT: Once = Once::new();
 
 fn init_logger() {
     INIT.call_once(|| {
-        let stdout = ConsoleAppender::builder().build();
-        let config = LogConfig::builder()
-            .appender(Appender::builder().build("stdout", Box::new(stdout)))
-            .build(Root::builder().appender("stdout").build(LevelFilter::Info))
-            .unwrap();
-        log4rs::init_config(config).unwrap();
+        xecute::logging::init_logger(&None).unwrap();
     });
 }
 

--- a/crates/menmos-xecute/Cargo.toml
+++ b/crates/menmos-xecute/Cargo.toml
@@ -20,5 +20,5 @@ num_cpus = "1.13"
 serde = {version = "1", features=["derive"]}
 serde_json = "1"
 tokio = {version = "1.2", features = ["full"]}
-tracing = {version = "0.1", features = ["max_level_trace", "release_max_level_info"]}
+tracing = {version = "0.1", features = ["max_level_trace", "release_max_level_debug"]}
 tracing-subscriber = "0.2"

--- a/crates/menmos-xecute/Cargo.toml
+++ b/crates/menmos-xecute/Cargo.toml
@@ -16,7 +16,9 @@ path = "src/lib.rs"
 anyhow = "1"
 async-trait = "0.1"
 clap = "3.0.0-beta.2"
-log4rs = "1"
-log = "0.4"
 num_cpus = "1.13"
+serde = {version = "1", features=["derive"]}
+serde_json = "1"
 tokio = {version = "1.2", features = ["full"]}
+tracing = {version = "0.1", features = ["max_level_trace", "release_max_level_info"]}
+tracing-subscriber = "0.2"

--- a/crates/menmos-xecute/src/lib.rs
+++ b/crates/menmos-xecute/src/lib.rs
@@ -1,6 +1,6 @@
 //! Library for spawning pre-configured processes.
 
 mod daemon;
-mod logging;
+pub mod logging;
 
 pub use daemon::{Daemon, DaemonProcess};

--- a/crates/rapidquery/Cargo.toml
+++ b/crates/rapidquery/Cargo.toml
@@ -13,7 +13,7 @@ bitvec_span = ["bitvec"]
 
 [dependencies]
 bitvec = {version = "0.20", features = ["serde"], optional = true}
-log = "0.4"
 nom = {version = "6.1"}
 serde = {version = "1", features = ["derive"]}
 snafu = "0.6"
+tracing = {version = "0.1", features = ["max_level_trace", "release_max_level_info"]}

--- a/crates/rapidquery/Cargo.toml
+++ b/crates/rapidquery/Cargo.toml
@@ -16,4 +16,4 @@ bitvec = {version = "0.20", features = ["serde"], optional = true}
 nom = {version = "6.1"}
 serde = {version = "1", features = ["derive"]}
 snafu = "0.6"
-tracing = {version = "0.1", features = ["max_level_trace", "release_max_level_info"]}
+tracing = {version = "0.1", features = ["max_level_trace", "release_max_level_debug"]}


### PR DESCRIPTION
Seems like a lot of changes, but there's no real change in behavior (besides `logging.rs` in xecute).

We now use tokio/tracing, which gives us better logging & error reporting.