### PR TITLE
[MEN-51] - Add an endpoint to get the effective node configuration

### DIFF
--- a/bin/menmosd/src/menmosd/server/filters/admin.rs
+++ b/bin/menmosd/src/menmosd/server/filters/admin.rs
@@ -10,6 +10,7 @@ const VERSION_PATH: &str = "version";
 const REBUILD_PATH: &str = "rebuild";
 const HEALTH_PATH: &str = "health";
 const FLUSH_PATH: &str = "flush";
+const CONFIG_PATH: &str = "config";
 
 pub fn all(
     context: Context,
@@ -18,7 +19,8 @@ pub fn all(
         .or(rebuild(context.clone()))
         .or(rebuild_complete(context.clone()))
         .or(flush(context.clone()))
-        .or(version(context))
+        .or(version(context.clone()))
+        .or(get_config(context))
 }
 
 fn health() -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
@@ -68,4 +70,15 @@ fn version(
         .and(user(context.config.node.encryption_key.clone()))
         .and(warp::path(VERSION_PATH))
         .and_then(handlers::admin::version)
+}
+
+fn get_config(
+    context: Context,
+) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
+    warp::get()
+        .and(user(context.config.node.encryption_key.clone()))
+        .and(with_context(context))
+        .and(warp::path(CONFIG_PATH))
+        .and(warp::path::end())
+        .and_then(handlers::admin::get_config)
 }

--- a/bin/menmosd/src/menmosd/server/handlers/admin/get_config.rs
+++ b/bin/menmosd/src/menmosd/server/handlers/admin/get_config.rs
@@ -1,0 +1,15 @@
+use apikit::auth::UserIdentity;
+use apikit::reject::Forbidden;
+
+use crate::server::Context;
+
+#[tracing::instrument(skip(context))]
+pub async fn get_config(
+    user: UserIdentity,
+    context: Context,
+) -> Result<impl warp::Reply, warp::Rejection> {
+    if !user.admin {
+        return Err(Forbidden.into());
+    }
+    Ok(apikit::reply::json(&*context.config))
+}

--- a/bin/menmosd/src/menmosd/server/handlers/admin/mod.rs
+++ b/bin/menmosd/src/menmosd/server/handlers/admin/mod.rs
@@ -1,10 +1,12 @@
 mod flush;
+mod get_config;
 mod health;
 mod rebuild;
 mod rebuild_complete;
 mod version;
 
 pub use flush::flush;
+pub use get_config::get_config;
 pub use health::health;
 pub use rebuild::rebuild;
 pub use rebuild_complete::rebuild_complete;


### PR DESCRIPTION
No functional tests because `menmos-cllient` can't get access to the menmosd config type without introducing a circular dependency.

Not a big deal though, endpoint is dead simple.