### PR TITLE
Add basic CORS

### DIFF
--- a/bin/menmosd/Cargo.toml
+++ b/bin/menmosd/Cargo.toml
@@ -35,7 +35,7 @@ anyhow = "1"
 axum = "0.4.8"
 axum-server = { version = "0.3.3", features = ["tls-rustls"] }
 axum-client-ip = "0.1.0"
-tower-http = { version = "0.2.5", features = ["trace"] }
+tower-http = { version = "0.2.5", features = ["trace", "cors"] }
 tower-request-id = "0.2.0"
 hyper = "0.14.17"
 

--- a/bin/menmosd/src/menmosd/server/router.rs
+++ b/bin/menmosd/src/menmosd/server/router.rs
@@ -1,4 +1,8 @@
+use axum::http::header::{AUTHORIZATION, CONTENT_TYPE};
 use axum::routing::*;
+use headers::HeaderName;
+use hyper::Method;
+use tower_http::cors::{Any, CorsLayer};
 
 use super::handlers;
 
@@ -30,6 +34,23 @@ fn blob() -> Router {
 }
 
 pub fn new() -> Router {
+    let cors = CorsLayer::new()
+        .allow_methods(vec![
+            Method::GET,
+            Method::POST,
+            Method::DELETE,
+            Method::PUT,
+            Method::OPTIONS,
+        ])
+        // TODO: add config to allows specifying whitelisted origins
+        .allow_origin(Any)
+        .allow_headers(vec![
+            CONTENT_TYPE,
+            AUTHORIZATION,
+            HeaderName::from_static("x-blob-meta"),
+            HeaderName::from_static("x-blob-size"),
+        ]);
+
     Router::new()
         // Admin Routes
         .route("/health", get(handlers::admin::health))
@@ -59,4 +80,5 @@ pub fn new() -> Router {
             "/web",
             Router::new().route("/*path", get(handlers::webui::serve_static)),
         )
+        .layer(cors)
 }

--- a/bin/menmosd/src/menmosd/server/router.rs
+++ b/bin/menmosd/src/menmosd/server/router.rs
@@ -1,8 +1,4 @@
-use axum::http::header::{AUTHORIZATION, CONTENT_TYPE};
 use axum::routing::*;
-use headers::HeaderName;
-use hyper::Method;
-use tower_http::cors::{Any, CorsLayer};
 
 use super::handlers;
 
@@ -34,23 +30,6 @@ fn blob() -> Router {
 }
 
 pub fn new() -> Router {
-    let cors = CorsLayer::new()
-        .allow_methods(vec![
-            Method::GET,
-            Method::POST,
-            Method::DELETE,
-            Method::PUT,
-            Method::OPTIONS,
-        ])
-        // TODO: add config to allows specifying whitelisted origins
-        .allow_origin(Any)
-        .allow_headers(vec![
-            CONTENT_TYPE,
-            AUTHORIZATION,
-            HeaderName::from_static("x-blob-meta"),
-            HeaderName::from_static("x-blob-size"),
-        ]);
-
     Router::new()
         // Admin Routes
         .route("/health", get(handlers::admin::health))
@@ -80,5 +59,4 @@ pub fn new() -> Router {
             "/web",
             Router::new().route("/*path", get(handlers::webui::serve_static)),
         )
-        .layer(cors)
 }


### PR DESCRIPTION
Self-explanatory.

Note: In another PR, we will add the logic that allows a user to set any custom origins for its CORS.