### PR TITLE
[MEN-147] - Use sharded mutex to protect amphora calls

### DIFF
--- a/bin/amphora/src/amphora/node/node_impl.rs
+++ b/bin/amphora/src/amphora/node/node_impl.rs
@@ -312,6 +312,7 @@ impl StorageNode for Storage {
 
     async fn delete(&self, blob_id: String, username: &str) -> Result<()> {
         let _guard = self.shard_lock.write(&blob_id).await;
+
         // Privilege check.
         ensure!(self.is_blob_owned_by(&blob_id, username)?, "forbidden");
 
@@ -333,6 +334,7 @@ impl StorageNode for Storage {
 
     async fn fsync(&self, blob_id: String, username: &str) -> Result<()> {
         let _guard = self.shard_lock.write(&blob_id).await;
+
         // Privilege check.
         ensure!(self.is_blob_owned_by(&blob_id, username)?, "forbidden");
 

--- a/bin/amphora/src/amphora/node/node_impl.rs
+++ b/bin/amphora/src/amphora/node/node_impl.rs
@@ -15,6 +15,8 @@ use futures::{stream::empty, Stream};
 
 use interface::{Blob, BlobInfo, BlobInfoRequest, CertificateInfo, StorageNode, StorageNodeInfo};
 
+use menmos_std::sync::ShardedMutex;
+
 use parking_lot::Mutex;
 
 use repository::{Repository, StreamInfo};
@@ -41,6 +43,8 @@ pub struct Storage {
     repo: Arc<ConcurrentRepository>,
 
     transfer_manager: Arc<AsyncMutex<Option<TransferManager>>>,
+
+    shard_lock: ShardedMutex,
 }
 
 impl Storage {
@@ -66,6 +70,9 @@ impl Storage {
 
         let transfer_manager = TransferManager::new(repo.clone(), index.clone(), config.clone());
 
+        // TODO: Tune this (and allow runtime tuning).
+        let shard_lock = ShardedMutex::new(10, 0.01);
+
         let s = Self {
             config,
             directory: proxy,
@@ -73,6 +80,7 @@ impl Storage {
             repo,
             certificates,
             transfer_manager: Arc::new(AsyncMutex::new(Some(transfer_manager))),
+            shard_lock,
         };
 
         Ok(s)
@@ -183,6 +191,8 @@ impl StorageNode for Storage {
         info_request: BlobInfoRequest,
         stream: Option<Box<dyn Stream<Item = Result<Bytes, io::Error>> + Send + Sync + Unpin>>,
     ) -> Result<()> {
+        let _guard = self.shard_lock.write(&id).await;
+
         let actual_blob_size = if let Some(s) = stream {
             self.repo.save(id.clone(), s).await?
         } else {
@@ -224,6 +234,8 @@ impl StorageNode for Storage {
         body: Bytes,
         username: &str,
     ) -> Result<()> {
+        let _guard = self.shard_lock.write(&id).await;
+
         // Privilege check.
         ensure!(self.is_blob_owned_by(&id, username)?, "forbidden");
 
@@ -248,6 +260,8 @@ impl StorageNode for Storage {
     }
 
     async fn get(&self, blob_id: String, range: Option<(Bound<u64>, Bound<u64>)>) -> Result<Blob> {
+        let _guard = self.shard_lock.read(&blob_id).await;
+
         // TODO: Clip the bounds to the real blob?
         let info: BlobInfo = self
             .index
@@ -273,6 +287,8 @@ impl StorageNode for Storage {
     }
 
     async fn update_meta(&self, blob_id: String, info_request: BlobInfoRequest) -> Result<()> {
+        let _guard = self.shard_lock.write(&blob_id).await;
+
         // Privilege check.
         ensure!(
             self.is_blob_owned_by(&blob_id, &info_request.owner)?,
@@ -295,6 +311,7 @@ impl StorageNode for Storage {
     }
 
     async fn delete(&self, blob_id: String, username: &str) -> Result<()> {
+        let _guard = self.shard_lock.write(&blob_id).await;
         // Privilege check.
         ensure!(self.is_blob_owned_by(&blob_id, username)?, "forbidden");
 
@@ -315,6 +332,7 @@ impl StorageNode for Storage {
     }
 
     async fn fsync(&self, blob_id: String, username: &str) -> Result<()> {
+        let _guard = self.shard_lock.write(&blob_id).await;
         // Privilege check.
         ensure!(self.is_blob_owned_by(&blob_id, username)?, "forbidden");
 

--- a/bin/menmosd/src/menmosd/server/handlers/admin/version.rs
+++ b/bin/menmosd/src/menmosd/server/handlers/admin/version.rs
@@ -2,13 +2,11 @@ use apikit::reject::HTTPError;
 
 use axum::Json;
 
-use menmos_auth::UserIdentity;
-
 use protocol::VersionResponse;
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 #[tracing::instrument]
-pub async fn version(_user: UserIdentity) -> Result<Json<VersionResponse>, HTTPError> {
+pub async fn version() -> Result<Json<VersionResponse>, HTTPError> {
     Ok(Json(VersionResponse::new(VERSION)))
 }

--- a/crates/menmos-xecute/src/daemon.rs
+++ b/crates/menmos-xecute/src/daemon.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::{path::PathBuf, process::exit};
 
 use anyhow::Result;
 use async_trait::async_trait;
@@ -86,6 +86,7 @@ impl DaemonProcess {
 
         if let Err(e) = main_loop(cfg, log_config, daemon) {
             tracing::error!("fatal: {}", e);
+            exit(1);
         }
     }
 }


### PR DESCRIPTION
Easy as pie!

Also included two quick features for a special project I'm working on:
- Return a proper status 1 in xecute when failing to parse the config
- Remove authentication requirement from `/version` endpoint on menmosd