### PR TITLE
[MEN-150] - Switch from chrono to time

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,7 +44,6 @@ dependencies = [
  "base64",
  "bincode",
  "bytes",
- "chrono",
  "clap",
  "config 0.10.1",
  "dirs",
@@ -70,6 +69,7 @@ dependencies = [
  "serde_json",
  "sled",
  "tempfile",
+ "time 0.3.9",
  "tokio",
  "tower-http",
  "tracing",
@@ -753,7 +753,6 @@ dependencies = [
  "libc",
  "num-integer",
  "num-traits 0.2.14",
- "serde 1.0.136",
  "time 0.1.44",
  "wasm-bindgen",
  "winapi",
@@ -1882,9 +1881,9 @@ dependencies = [
  "axum",
  "bincode",
  "branca",
- "chrono",
  "menmos-apikit",
  "serde 1.0.136",
+ "time 0.3.9",
  "tracing",
 ]
 
@@ -1944,13 +1943,13 @@ dependencies = [
  "async-trait",
  "base64",
  "bytes",
- "chrono",
  "futures",
  "headers",
  "nom 7.1.1",
  "rapidquery",
  "reqwest",
  "serde 1.0.136",
+ "time 0.3.9",
 ]
 
 [[package]]
@@ -2053,7 +2052,6 @@ dependencies = [
  "bitvec",
  "byteorder",
  "bytes",
- "chrono",
  "clap",
  "config 0.10.1",
  "dirs",
@@ -3577,6 +3575,7 @@ dependencies = [
  "itoa",
  "libc",
  "num_threads",
+ "serde 1.0.136",
  "time-macros 0.2.4",
 ]
 

--- a/bin/amphora/Cargo.toml
+++ b/bin/amphora/Cargo.toml
@@ -31,7 +31,6 @@ async-trait = "0.1.53"
 base64 = "0.13"
 bincode = "1.3.1"
 bytes = "1.0"
-chrono = "0.4"
 clap = { version = "3.1.8", features = ["derive"] }
 config = { git = "https://github.com/dalloriam/config-rs", branch = "parse-env-numbers" }
 dirs = "4"
@@ -53,5 +52,6 @@ reqwest = { version = "0.11", features = ["json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sled = { git = "https://github.com/spacejam/sled", branch = "main" }
+time = "0.3.9"
 tokio = { version = "1.16", features = ["full"] }
 tracing = { version = "0.1", features = ["max_level_trace", "release_max_level_debug"] }

--- a/bin/amphora/Cargo.toml
+++ b/bin/amphora/Cargo.toml
@@ -52,6 +52,6 @@ reqwest = { version = "0.11", features = ["json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sled = { git = "https://github.com/spacejam/sled", branch = "main" }
-time = "0.3.9"
+time = {version = "0.3.9", features=["serde"]}
 tokio = { version = "1.16", features = ["full"] }
 tracing = { version = "0.1", features = ["max_level_trace", "release_max_level_debug"] }

--- a/bin/amphora/src/amphora/node/node_impl.rs
+++ b/bin/amphora/src/amphora/node/node_impl.rs
@@ -9,8 +9,6 @@ use async_trait::async_trait;
 
 use bytes::Bytes;
 
-use chrono::Utc;
-
 use futures::{stream::empty, Stream};
 
 use interface::{Blob, BlobInfo, BlobInfoRequest, CertificateInfo, StorageNode, StorageNodeInfo};
@@ -21,6 +19,7 @@ use parking_lot::Mutex;
 
 use repository::{Repository, StreamInfo};
 
+use time::OffsetDateTime;
 use tokio::sync::Mutex as AsyncMutex;
 
 use super::{
@@ -213,7 +212,7 @@ impl StorageNode for Storage {
         let (created_at, modified_at) = if let Some(old_info) = self.index.get(&id)? {
             (old_info.meta.created_at, old_info.meta.modified_at)
         } else {
-            let date = Utc::now();
+            let date = OffsetDateTime::now_utc();
             (date, date)
         };
 
@@ -244,7 +243,7 @@ impl StorageNode for Storage {
 
         // Update the index.
         if let Some(mut info) = self.index.get(&id)? {
-            info.meta.modified_at = Utc::now();
+            info.meta.modified_at = OffsetDateTime::now_utc();
             info.meta.size = new_blob_size;
             self.index.insert(&id, &info)?;
 
@@ -296,7 +295,8 @@ impl StorageNode for Storage {
         );
 
         if let Some(old_info) = self.index.get(&blob_id)? {
-            let mut info = info_request.into_blob_info(old_info.meta.created_at, Utc::now());
+            let mut info =
+                info_request.into_blob_info(old_info.meta.created_at, OffsetDateTime::now_utc());
             info.meta.size = old_info.meta.size; // carry-over the old size because changing the metadata doesn't change the size
             self.index.insert(&blob_id, &info)?;
 

--- a/bin/menmosd/Cargo.toml
+++ b/bin/menmosd/Cargo.toml
@@ -47,7 +47,6 @@ bincode = "1.3.1"
 bitvec = { version = "1.0", features = ["serde"] }
 byteorder = "1.4.2"
 bytes = "1.0"
-chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "3.1.8", features = ["derive"] }
 config = { git = "https://github.com/dalloriam/config-rs", branch = "parse-env-numbers" }
 dirs = "4"
@@ -69,7 +68,7 @@ rust-argon2 = "1.0"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sled = { git = "https://github.com/spacejam/sled", branch = "main" }
-time = "0.3.9"
+time = {version = "0.3.9", features = ["serde"]}
 tracing = { version = "0.1", features = ["max_level_trace", "release_max_level_debug"] }
 tokio = { version = "1.16", features = ["full"] }
 uuid = { version = "0.8", features = ["serde", "v4"] }

--- a/bin/menmosd/src/menmosd/node/test/node.rs
+++ b/bin/menmosd/src/menmosd/node/test/node.rs
@@ -4,12 +4,11 @@ use std::net::IpAddr;
 
 use anyhow::Result;
 
-use chrono::Utc;
-
 use interface::{
     BlobInfo, BlobInfoRequest, BlobMetaRequest, DirectoryNode, FieldValue, Query, QueryResponse,
     RoutingConfig, StorageNodeInfo,
 };
+use time::OffsetDateTime;
 
 use crate::Directory;
 
@@ -50,7 +49,11 @@ async fn index<S: AsRef<str>>(
             id.as_ref(),
             BlobInfo {
                 owner: "admin".to_string(),
-                meta: meta_request.into_meta(Utc::now(), Utc::now(), 0),
+                meta: meta_request.into_meta(
+                    OffsetDateTime::now_utc(),
+                    OffsetDateTime::now_utc(),
+                    0,
+                ),
             },
             &tgt_storage_node.id,
         )

--- a/crates/menmos-auth/Cargo.toml
+++ b/crates/menmos-auth/Cargo.toml
@@ -14,7 +14,7 @@ async-trait = "0.1.53"
 axum = { version = "0.4.8", features = ["headers"] }
 bincode = "1.3.3"
 branca = "0.10.1"
-chrono = "0.4.19"
-menmos-apikit = { "version" = "^0.1.1" }
+menmos-apikit = { version = "^0.1.1" }
 serde = { version = "1.0.136", features = ["derive"] }
+time = "0.3.9"
 tracing = { version = "0.1.32", features = ["max_level_trace", "release_max_level_debug"] }

--- a/crates/menmos-auth/src/lib.rs
+++ b/crates/menmos-auth/src/lib.rs
@@ -48,7 +48,7 @@ pub fn make_token<K: AsRef<str>, D: Serialize>(key: K, data: D) -> anyhow::Resul
     let mut token = Branca::new(key.as_ref().as_bytes())?;
     token
         .set_ttl(TOKEN_TTL_SECONDS)
-        .set_timestamp(chrono::Utc::now().timestamp() as u32);
+        .set_timestamp(time::OffsetDateTime::now_utc().unix_timestamp() as u32);
 
     let encoded_body = bincode::serialize(&data)?;
     Ok(token.encode(&encoded_body)?)

--- a/crates/menmos-interface/Cargo.toml
+++ b/crates/menmos-interface/Cargo.toml
@@ -17,10 +17,10 @@ anyhow = "1"
 base64 = "0.13"
 bytes = "1"
 async-trait = "0.1.53"
-chrono = { version = "0.4", features = ["serde"] }
 futures = "0.3"
 headers = "0.3.7"
 nom = "7.1.1"
 rapidquery = { version = "^0.1.0", features = ["bitvec_size", "parse"] }
 reqwest = { version = "0.11", features = ["json", "stream"] }
 serde = { version = "1.0", features = ["derive"] }
+time = {version = "0.3.9", features = ["serde"]}

--- a/crates/menmos-interface/Cargo.toml
+++ b/crates/menmos-interface/Cargo.toml
@@ -23,4 +23,4 @@ nom = "7.1.1"
 rapidquery = { version = "^0.1.0", features = ["bitvec_size", "parse"] }
 reqwest = { version = "0.11", features = ["json", "stream"] }
 serde = { version = "1.0", features = ["derive"] }
-time = {version = "0.3.9", features = ["serde"]}
+time = {version = "0.3.9", features = ["serde", "serde-well-known"]}

--- a/crates/menmos-interface/src/lib.rs
+++ b/crates/menmos-interface/src/lib.rs
@@ -1,5 +1,6 @@
 mod directory;
 mod storage;
+mod timestamp_nanos;
 
 pub use directory::*;
 pub use storage::*;

--- a/crates/menmos-interface/src/storage.rs
+++ b/crates/menmos-interface/src/storage.rs
@@ -162,9 +162,11 @@ pub struct BlobMeta {
     pub size: u64,
 
     /// This blob's creation time.
+    #[serde(with = "time::serde::rfc3339")]
     pub created_at: OffsetDateTime,
 
     /// This blob's last modified time.
+    #[serde(with = "time::serde::rfc3339")]
     pub modified_at: OffsetDateTime,
 }
 
@@ -230,9 +232,11 @@ pub struct TaggedBlobMeta {
     pub size: u64,
 
     /// This blob's creation time.
+    #[serde(with = "crate::timestamp_nanos")]
     pub created_at: OffsetDateTime,
 
     /// This blob's last modified time.
+    #[serde(with = "crate::timestamp_nanos")]
     pub modified_at: OffsetDateTime,
 }
 

--- a/crates/menmos-interface/src/storage.rs
+++ b/crates/menmos-interface/src/storage.rs
@@ -12,11 +12,10 @@ use async_trait::async_trait;
 
 use bytes::Bytes;
 
-use chrono::{DateTime, Utc};
-
 use futures::Stream;
 
 use serde::{Deserialize, Serialize};
+use time::OffsetDateTime;
 
 fn file_to_base64<P: AsRef<Path>>(path: P) -> Result<String> {
     Ok(base64::encode(fs::read(path.as_ref())?))
@@ -71,8 +70,8 @@ impl BlobMetaRequest {
 
     pub fn into_meta(
         self,
-        created_at: DateTime<Utc>,
-        modified_at: DateTime<Utc>,
+        created_at: OffsetDateTime,
+        modified_at: OffsetDateTime,
         size: u64,
     ) -> BlobMeta {
         BlobMeta {
@@ -163,10 +162,10 @@ pub struct BlobMeta {
     pub size: u64,
 
     /// This blob's creation time.
-    pub created_at: DateTime<Utc>,
+    pub created_at: OffsetDateTime,
 
     /// This blob's last modified time.
-    pub modified_at: DateTime<Utc>,
+    pub modified_at: OffsetDateTime,
 }
 
 impl From<BlobMeta> for BlobMetaRequest {
@@ -184,8 +183,8 @@ impl Default for BlobMeta {
             fields: Default::default(),
             tags: Default::default(),
             size: 0,
-            created_at: Utc::now(),
-            modified_at: Utc::now(),
+            created_at: OffsetDateTime::now_utc(),
+            modified_at: OffsetDateTime::now_utc(),
         }
     }
 }
@@ -231,10 +230,10 @@ pub struct TaggedBlobMeta {
     pub size: u64,
 
     /// This blob's creation time.
-    pub created_at: DateTime<Utc>,
+    pub created_at: OffsetDateTime,
 
     /// This blob's last modified time.
-    pub modified_at: DateTime<Utc>,
+    pub modified_at: OffsetDateTime,
 }
 
 impl From<BlobMeta> for TaggedBlobMeta {
@@ -278,7 +277,11 @@ pub struct BlobInfoRequest {
 }
 
 impl BlobInfoRequest {
-    pub fn into_blob_info(self, created_at: DateTime<Utc>, modified_at: DateTime<Utc>) -> BlobInfo {
+    pub fn into_blob_info(
+        self,
+        created_at: OffsetDateTime,
+        modified_at: OffsetDateTime,
+    ) -> BlobInfo {
         BlobInfo {
             meta: self
                 .meta_request

--- a/crates/menmos-interface/src/timestamp_nanos.rs
+++ b/crates/menmos-interface/src/timestamp_nanos.rs
@@ -1,0 +1,18 @@
+use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
+
+use time::OffsetDateTime;
+
+/// Serialize an `OffsetDateTime` as its Unix timestamp
+pub fn serialize<S: Serializer>(
+    datetime: &OffsetDateTime,
+    serializer: S,
+) -> Result<S::Ok, S::Error> {
+    datetime.unix_timestamp_nanos().serialize(serializer)
+}
+
+/// Deserialize an `OffsetDateTime` from its Unix timestamp
+pub fn deserialize<'a, D: Deserializer<'a>>(deserializer: D) -> Result<OffsetDateTime, D::Error> {
+    let value = <_>::deserialize(deserializer)?;
+    OffsetDateTime::from_unix_timestamp_nanos(value)
+        .map_err(|err| de::Error::invalid_value(de::Unexpected::Other(&format!("{value}")), &err))
+}


### PR DESCRIPTION
This switches all components to use `time` instead of `chrono` (because chrono hasn't had a release in a while and has unaddressed security advisories while time is more actively maintained).

Some changes were needed to how we serialize the `BlobInfo` and `TaggedBlobInfo` structs, because the RFC-3339 serialization implementation provided by `time` uses the `serde::deserialize_any`, which isn't supported by `bincode` (the format we use for sled serialization). 

I added a custom serde serializer to `TaggedBlobInfo` (which is the only structure serialized to bincode) that serializes datetimes to a nanosecond unix timestamp, and used the built-in rfc3339 serializer to serialize `BlobInfo` (which is client-facing and serialized to JSON only).

Therefore, this PR introduces a breaking change to the sled index format, but no change to the API.